### PR TITLE
enable NINA alerts for Germany

### DIFF
--- a/config.template
+++ b/config.template
@@ -147,6 +147,10 @@ ignoreFEMAtest = True
 # find your SAME https://www.weather.gov/nwr/counties
 mySAME = 053029,053073
 enableGBalerts = False
+enableDEalerts = False
+# comma separated list of regional codes trigger local alert.
+# find your regional codet at https://www.xrepository.de/api/xrepository/urn:de:bund:destatis:bevoelkerungsstatistik:schluessel:rs_2021-07-31/download/Regionalschl_ssel_2021-07-31.json
+myRegionalKeys = 110000000000,120510000000
 
 # Satalite Pass Prediction
 # Register for free API https://www.n2yo.com/login/

--- a/mesh_bot.py
+++ b/mesh_bot.py
@@ -694,6 +694,9 @@ def handle_wxc(message_from_id, deviceID, cmd):
 
 def handle_emergency_alerts(message, message_from_id, deviceID):
     location = get_node_location(message_from_id, deviceID)
+    if enableDEalerts:
+        # nina Alerts
+        return get_nina_alerts()
     if enableGBalerts:
         # UK Alerts
         return get_govUK_alerts(str(location[0]), str(location[1]))

--- a/modules/globalalert.py
+++ b/modules/globalalert.py
@@ -27,7 +27,31 @@ def get_govUK_alerts(shortAlerts=False):
         return "🚨" + alert.get_text(strip=True)
     else:
         return NO_ALERTS
-    
+
+def get_nina_alerts():
+    try:
+        # get api.bund.dev alerts
+        alerts = []
+
+        for regionalKey in myRegionalKeys:
+
+            url = (
+                "https://nina.api.proxy.bund.dev/api31/dashboard/" + regionalKey + ".json"
+            )
+            response = requests.get(url)
+            data = response.json()
+
+
+            for item in data:
+                title = item["i18nTitle"]["de"]
+                alerts.append(f"🚨 {title}")
+
+
+        return "\n".join(alerts) if alerts else NO_ALERTS
+
+    except Exception as e:
+        logger.warning("Error getting NINA alerts: " + str(e))
+        return NO_ALERTS
 
 def get_wxUKgov():
     # get UK weather warnings

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -165,8 +165,10 @@ try:
     emergencyAlertBrodcastEnabled = config['location'].getboolean('eAlertBroadcastEnabled', False) # default False
     wxAlertBroadcastEnabled = config['location'].getboolean('wxAlertBroadcastEnabled', False) # default False
     enableGBalerts = config['location'].getboolean('enableGBalerts', False) # default False
+    enableDEalerts = config['location'].getboolean('enableDEalerts', False) # default False
     wxAlertsEnabled = config['location'].getboolean('NOAAalertsEnabled', True) # default True
     mySAME = config['location'].get('mySAME', '').split(',') # default empty
+    myRegionalKeys = config['location'].get('myRegionalKeys', '110000000000').split(',') # default city Berlin
     forecastDuration = config['location'].getint('NOAAforecastDuration', 4) # NOAA forcast days
     numWxAlerts = config['location'].getint('NOAAalertCount', 2) # default 2 alerts
     ipawsPIN = config['location'].get('ipawsPIN', '000000') # default 000000

--- a/modules/system.py
+++ b/modules/system.py
@@ -671,6 +671,7 @@ def handleMultiPing(nodeID=0, deviceID=1):
 
 def handleAlertBroadcast(deviceID=1):
     alertUk = NO_ALERTS
+    alertDe = NO_ALERTS
     alertFema = NO_ALERTS
     wxAlert = NO_ALERTS
     # only allow API call every 20 minutes
@@ -686,6 +687,8 @@ def handleAlertBroadcast(deviceID=1):
         alertWx = alertBrodcastNOAA()
 
     if emergencyAlertBrodcastEnabled:
+        if enableDEalerts:
+            alertDe = get_nina_alerts()
         if enableGBalerts:
             alertUk = get_govUK_alerts()
         else:
@@ -700,6 +703,7 @@ def handleAlertBroadcast(deviceID=1):
 
     femaAlert = alertFema
     ukAlert = alertUk
+    deAlert = alertDe
 
     if emergencyAlertBrodcastEnabled:
         if NO_ALERTS not in femaAlert and ERROR_FETCHING_DATA not in femaAlert:
@@ -710,6 +714,14 @@ def handleAlertBroadcast(deviceID=1):
                 send_message(femaAlert, emergencyAlertBroadcastCh, 0, deviceID)
             return True
         if NO_ALERTS not in ukAlert:
+            if isinstance(emergencyAlertBroadcastCh, list):
+                for channel in emergencyAlertBroadcastCh:
+                    send_message(ukAlert, int(channel), 0, deviceID)
+            else:
+                send_message(ukAlert, emergencyAlertBroadcastCh, 0, deviceID)
+            return True
+
+        if NO_ALERTS not in deAlert:
             if isinstance(emergencyAlertBroadcastCh, list):
                 for channel in emergencyAlertBroadcastCh:
                     send_message(ukAlert, int(channel), 0, deviceID)


### PR DESCRIPTION
WIP on enabling alerts for Germany using [NINA api](https://nina.api.bund.dev).

Some notes:

- I tried to make minimal changes to existing code
- If we have both `enableGBalerts` and `enableDEalerts` set to `True` one of them needs to have precedence. Maybe something like `globalAlerts = DE` would make more sense?