### PR TITLE
Fix KeyError by using .get() for neighborinfo in system module

### DIFF
--- a/modules/system.py
+++ b/modules/system.py
@@ -1,28 +1,31 @@
 # helper functions and init for system related tasks
 # K7MHI Kelly Keeton 2024
 
-import meshtastic.serial_interface #pip install meshtastic or use launch.sh for venv
+# pip install meshtastic or use launch.sh for venv
+import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.ble_interface
 import time
 import asyncio
 import random
-import contextlib # for suppressing output on watchdog
-import io # for suppressing output on watchdog
+import contextlib  # for suppressing output on watchdog
+import io  # for suppressing output on watchdog
 from modules.log import *
 
 # Global Variables
-debugMetadata = False # packet debug for non text messages
-trap_list = ("cmd","cmd?") # default trap list
+debugMetadata = False  # packet debug for non text messages
+trap_list = ("cmd", "cmd?")  # default trap list
 help_message = "Bot CMD?:"
 asyncLoop = asyncio.new_event_loop()
 games_enabled = False
-multiPingList = [{'message_from_id': 0, 'count': 0, 'type': '', 'deviceID': 0, 'channel_number': 0, 'startCount': 0}]
+multiPingList = [{'message_from_id': 0, 'count': 0, 'type': '',
+                  'deviceID': 0, 'channel_number': 0, 'startCount': 0}]
 
 # Ping Configuration
 if ping_enabled:
     # ping, pinging, ack, testing, test, pong
-    trap_list_ping = ("ping", "pinging", "ack", "testing", "test", "pong", "🔔", "cq","cqcq", "cqcqcq")
+    trap_list_ping = ("ping", "pinging", "ack", "testing",
+                      "test", "pong", "🔔", "cq", "cqcq", "cqcqcq")
     trap_list = trap_list + trap_list_ping
     help_message = help_message + "ping"
 
@@ -40,15 +43,16 @@ if motd_enabled:
 
 # SMTP Configuration
 if enableSMTP:
-    from modules.smtp import * # from the spudgunman/meshing-around repo
+    from modules.smtp import *  # from the spudgunman/meshing-around repo
     trap_list = trap_list + trap_list_smtp
     help_message = help_message + ", email:, sms:"
 
 # Emergency Responder Configuration
 if emergency_responder_enabled:
-    trap_list_emergency = ("emergency", "911", "112", "999", "police", "fire", "ambulance", "rescue")
+    trap_list_emergency = ("emergency", "911", "112",
+                           "999", "police", "fire", "ambulance", "rescue")
     trap_list = trap_list + trap_list_emergency
-    
+
 # whoami Configuration
 if whoami_enabled:
     trap_list_whoami = ("whoami", "📍", "whois")
@@ -57,8 +61,8 @@ if whoami_enabled:
 
 # Solar Conditions Configuration
 if solar_conditions_enabled:
-    from modules.space import * # from the spudgunman/meshing-around repo
-    trap_list = trap_list + trap_list_solarconditions # items hfcond, solar, sun, moon
+    from modules.space import *  # from the spudgunman/meshing-around repo
+    trap_list = trap_list + trap_list_solarconditions  # items hfcond, solar, sun, moon
     help_message = help_message + ", sun, hfcond, solar, moon"
     if n2yoAPIKey != "":
         help_message = help_message + ", satpass"
@@ -68,33 +72,34 @@ else:
 # Command History Configuration
 if enableCmdHistory:
     trap_list = trap_list + ("history",)
-    #help_message = help_message + ", history"
+    # help_message = help_message + ", history"
 
 # Location Configuration
 if location_enabled:
-    from modules.locationdata import * # from the spudgunman/meshing-around repo
-    trap_list = trap_list + trap_list_location # items tide, whereami, wxc, wx
+    from modules.locationdata import *  # from the spudgunman/meshing-around repo
+    trap_list = trap_list + trap_list_location  # items tide, whereami, wxc, wx
     help_message = help_message + ", whereami, wx, wxc, rlist"
     if enableGBalerts and not enableDEalerts:
-        from modules.globalalert import * # from the spudgunman/meshing-around repo
+        from modules.globalalert import *  # from the spudgunman/meshing-around repo
         trap_list = trap_list + trap_list_location_eu
-        #help_message = help_message + ", ukalert, ukwx, ukflood"
+        # help_message = help_message + ", ukalert, ukwx, ukflood"
     if enableDEalerts and not enableGBalerts:
-        from modules.globalalert import * # from the spudgunman/meshing-around repo
+        from modules.globalalert import *  # from the spudgunman/meshing-around repo
         trap_list = trap_list + trap_list_location_de
-        #help_message = help_message + ", dealert, dewx, deflood"
-    
+        # help_message = help_message + ", dealert, dewx, deflood"
+
     # Open-Meteo Configuration for worldwide weather
     if use_meteo_wxApi:
-        from modules.wx_meteo import * # from the spudgunman/meshing-around repo
+        from modules.wx_meteo import *  # from the spudgunman/meshing-around repo
     else:
         # NOAA only features
         help_message = help_message + ", wxa, tide, ealert"
-        
+
 # BBS Configuration
 if bbs_enabled:
-    from modules.bbstools import * # from the spudgunman/meshing-around repo
-    trap_list = trap_list + trap_list_bbs # items bbslist, bbspost, bbsread, bbsdelete, bbshelp
+    from modules.bbstools import *  # from the spudgunman/meshing-around repo
+    # items bbslist, bbspost, bbsread, bbsdelete, bbshelp
+    trap_list = trap_list + trap_list_bbs
     help_message = help_message + ", bbslist, bbshelp"
 else:
     bbs_help = False
@@ -102,56 +107,57 @@ else:
 
 # Dad Jokes Configuration
 if dad_jokes_enabled:
-    from modules.games.joke import * # from the spudgunman/meshing-around repo
+    from modules.games.joke import *  # from the spudgunman/meshing-around repo
     trap_list = trap_list + ("joke",)
     help_message = help_message + ", joke"
 
 # Wikipedia Search Configuration
 if wikipedia_enabled:
-    import wikipedia # pip install wikipedia
+    import wikipedia  # pip install wikipedia
     trap_list = trap_list + ("wiki:", "wiki?",)
     help_message = help_message + ", wiki:"
 
 # LLM Configuration
 if llm_enabled:
-    from modules.llm import * # from the spudgunman/meshing-around repo
-    trap_list = trap_list + trap_list_llm # items ask:
+    from modules.llm import *  # from the spudgunman/meshing-around repo
+    trap_list = trap_list + trap_list_llm  # items ask:
     help_message = help_message + ", askai"
 
 # DopeWars Configuration
 if dopewars_enabled:
-    from modules.games.dopewar import * # from the spudgunman/meshing-around repo
+    from modules.games.dopewar import *  # from the spudgunman/meshing-around repo
     trap_list = trap_list + ("dopewars",)
     games_enabled = True
 
 # Lemonade Stand Configuration
 if lemonade_enabled:
-    from modules.games.lemonade import * # from the spudgunman/meshing-around repo
+    from modules.games.lemonade import *  # from the spudgunman/meshing-around repo
     trap_list = trap_list + ("lemonstand",)
     games_enabled = True
 
 # BlackJack Configuration
 if blackjack_enabled:
-    from modules.games.blackjack import * # from the spudgunman/meshing-around repo
+    from modules.games.blackjack import *  # from the spudgunman/meshing-around repo
     trap_list = trap_list + ("blackjack",)
     games_enabled = True
 
 # Video Poker Configuration
 if videoPoker_enabled:
-    from modules.games.videopoker import * # from the spudgunman/meshing-around repo
+    # from the spudgunman/meshing-around repo
+    from modules.games.videopoker import *
     trap_list = trap_list + ("videopoker",)
     games_enabled = True
 
 if mastermind_enabled:
-    from modules.games.mmind import * # from the spudgunman/meshing-around repo
+    from modules.games.mmind import *  # from the spudgunman/meshing-around repo
     trap_list = trap_list + ("mastermind",)
     games_enabled = True
 
 if golfSim_enabled:
-    from modules.games.golfsim import * # from the spudgunman/meshing-around repo
+    from modules.games.golfsim import *  # from the spudgunman/meshing-around repo
     trap_list = trap_list + ("golfsim",)
     games_enabled = True
-    
+
 # Games Configuration
 if games_enabled is True:
     help_message = help_message + ", games"
@@ -172,18 +178,18 @@ if games_enabled is True:
         gamesCmdList += "masterMind, "
     if golfSim_enabled:
         gamesCmdList += "golfSim, "
-    gamesCmdList = gamesCmdList[:-2] # remove the last comma
+    gamesCmdList = gamesCmdList[:-2]  # remove the last comma
 else:
     gamesCmdList = ""
 
 # Scheduled Broadcast Configuration
 if scheduler_enabled:
-    import schedule # pip install schedule
+    import schedule  # pip install schedule
 
 # Sentry Configuration
 if sentry_enabled:
     from math import sqrt
-    import geopy.distance # pip install geopy
+    import geopy.distance  # pip install geopy
 
 # Store and Forward Configuration
 if store_forward_enabled:
@@ -192,25 +198,26 @@ if store_forward_enabled:
 
 # QRZ Configuration
 if qrz_hello_enabled:
-    from modules.qrz import * # from the spudgunman/meshing-around repo
-    #trap_list = trap_list + trap_list_qrz # items qrz, qrz?, qrzcall
-    #help_message = help_message + ", qrz"
+    from modules.qrz import *  # from the spudgunman/meshing-around repo
+    # trap_list = trap_list + trap_list_qrz # items qrz, qrz?, qrzcall
+    # help_message = help_message + ", qrz"
 
 # CheckList Configuration
 if checklist_enabled:
-    from modules.checklist import * # from the spudgunman/meshing-around repo
-    trap_list = trap_list + trap_list_checklist # items checkin, checkout, checklist, purgein, purgeout
+    from modules.checklist import *  # from the spudgunman/meshing-around repo
+    # items checkin, checkout, checklist, purgein, purgeout
+    trap_list = trap_list + trap_list_checklist
     help_message = help_message + ", checkin, checkout"
 
 # Radio Monitor Configuration
 if radio_detection_enabled:
-    from modules.radio import * # from the spudgunman/meshing-around repo
+    from modules.radio import *  # from the spudgunman/meshing-around repo
 
 # File Monitor Configuration
 if file_monitor_enabled or read_news_enabled or bee_enabled:
-    from modules.filemon import * # from the spudgunman/meshing-around repo
+    from modules.filemon import *  # from the spudgunman/meshing-around repo
     if read_news_enabled:
-        trap_list = trap_list + trap_list_filemon # items readnews
+        trap_list = trap_list + trap_list_filemon  # items readnews
         help_message = help_message + ", readnews"
     # Bee Configuration uses file monitor module
     if bee_enabled:
@@ -221,13 +228,16 @@ help_message = help_message.split(", ")
 help_message.sort()
 if len(help_message) > 20:
     # split in half for formatting
-    help_message = help_message[:len(help_message)//2] + ["\nCMD?"] + help_message[len(help_message)//2:]
+    help_message = help_message[:len(
+        help_message)//2] + ["\nCMD?"] + help_message[len(help_message)//2:]
 help_message = ", ".join(help_message)
 
 # BLE dual interface prevention
-ble_count = sum(1 for i in range(1, 10) if globals().get(f'interface{i}_type') == 'ble')
+ble_count = sum(1 for i in range(1, 10) if globals().get(
+    f'interface{i}_type') == 'ble')
 if ble_count > 1:
-    logger.critical(f"System: Multiple BLE interfaces detected. Only one BLE interface is allowed. Exiting")
+    logger.critical(
+        f"System: Multiple BLE interfaces detected. Only one BLE interface is allowed. Exiting")
     exit()
 
 # Initialize interfaces
@@ -242,13 +252,17 @@ for i in range(1, 10):
     try:
         if globals().get(f'interface{i}_enabled'):
             if interface_type == 'serial':
-                globals()[f'interface{i}'] = meshtastic.serial_interface.SerialInterface(globals().get(f'port{i}'))
+                globals()[f'interface{i}'] = meshtastic.serial_interface.SerialInterface(
+                    globals().get(f'port{i}'))
             elif interface_type == 'tcp':
-                globals()[f'interface{i}'] = meshtastic.tcp_interface.TCPInterface(globals().get(f'hostname{i}'))
+                globals()[f'interface{i}'] = meshtastic.tcp_interface.TCPInterface(
+                    globals().get(f'hostname{i}'))
             elif interface_type == 'ble':
-                globals()[f'interface{i}'] = meshtastic.ble_interface.BLEInterface(globals().get(f'mac{i}'))
+                globals()[f'interface{i}'] = meshtastic.ble_interface.BLEInterface(
+                    globals().get(f'mac{i}'))
             else:
-                logger.critical(f"System: Interface Type: {interface_type} not supported. Validate your config against config.template Exiting")
+                logger.critical(
+                    f"System: Interface Type: {interface_type} not supported. Validate your config against config.template Exiting")
                 exit()
     except Exception as e:
         logger.critical(f"System: abort. Initializing Interface{i} {e}")
@@ -258,22 +272,27 @@ for i in range(1, 10):
 for i in range(1, 10):
     if globals().get(f'interface{i}') and globals().get(f'interface{i}_enabled'):
         try:
-            globals()[f'myNodeNum{i}'] = globals()[f'interface{i}'].getMyNodeInfo()['num']
-            logger.debug(f"System: Initalized Radio Device{i} Node Number: {globals()[f'myNodeNum{i}']}")
+            globals()[f'myNodeNum{i}'] = globals()[
+                f'interface{i}'].getMyNodeInfo()['num']
+            logger.debug(
+                f"System: Initalized Radio Device{i} Node Number: {globals()[f'myNodeNum{i}']}")
         except Exception as e:
-            logger.critical(f"System: critical error initializing interface{i} {e}")
+            logger.critical(
+                f"System: critical error initializing interface{i} {e}")
     else:
         globals()[f'myNodeNum{i}'] = 777
 
 #### FUN-ctions ####
 
+
 def decimal_to_hex(decimal_number):
     return f"!{decimal_number:08x}"
+
 
 def get_name_from_number(number, type='long', nodeInt=1):
     interface = globals()[f'interface{nodeInt}']
     name = ""
-    
+
     for node in interface.nodes.values():
         if number == node['num']:
             if type == 'long':
@@ -283,16 +302,18 @@ def get_name_from_number(number, type='long', nodeInt=1):
                 name = node['user']['shortName']
                 return name
         else:
-            name =  str(decimal_to_hex(number))  # If name not found, use the ID as string
+            # If name not found, use the ID as string
+            name = str(decimal_to_hex(number))
     return name
 
 
 def get_num_from_short_name(short_name, nodeInt=1):
     interface = globals()[f'interface{nodeInt}']
     # Get the node number from the short name, converting all to lowercase for comparison (good practice?)
-    logger.debug(f"System: Getting Node Number from Short Name: {short_name} on Device: {nodeInt}")
+    logger.debug(
+        f"System: Getting Node Number from Short Name: {short_name} on Device: {nodeInt}")
     for node in interface.nodes.values():
-        #logger.debug(f"System: Checking Node: {node['user']['shortName']} against {short_name} for number {node['num']}")
+        # logger.debug(f"System: Checking Node: {node['user']['shortName']} against {short_name} for number {node['num']}")
         if short_name == node['user']['shortName']:
             return node['num']
         elif str(short_name.lower()) == node['user']['shortName'].lower():
@@ -307,7 +328,8 @@ def get_num_from_short_name(short_name, nodeInt=1):
                         elif str(short_name.lower()) == node['user']['shortName'].lower():
                             return node['num']
     return 0
-    
+
+
 def get_node_list(nodeInt=1):
     interface = globals()[f'interface{nodeInt}']
     # Get a list of nodes on the device
@@ -325,26 +347,30 @@ def get_node_list(nodeInt=1):
 
                 # issue where lastHeard is not always present
                 last_heard = node.get('lastHeard', 0)
-                
+
                 # make a list of nodes with last heard time and SNR
                 item = (node_name, last_heard, snr)
                 node_list1.append(item)
     else:
         logger.warning(f"System: No nodes found")
         return ERROR_FETCHING_DATA
-    
+
     try:
-        #print (f"Node List: {node_list1[:5]}\n")
-        node_list1.sort(key=lambda x: x[1] if x[1] is not None else 0, reverse=True)
-        #print (f"Node List: {node_list1[:5]}\n")
+        # print (f"Node List: {node_list1[:5]}\n")
+        node_list1.sort(key=lambda x: x[1] if x[1]
+                        is not None else 0, reverse=True)
+        # print (f"Node List: {node_list1[:5]}\n")
         if multiple_interface:
-            logger.debug(f"System: FIX ME line 327 Multiple Interface Node List")
-            node_list2.sort(key=lambda x: x[1] if x[1] is not None else 0, reverse=True)
+            logger.debug(
+                f"System: FIX ME line 327 Multiple Interface Node List")
+            node_list2.sort(
+                key=lambda x: x[1] if x[1] is not None else 0, reverse=True)
     except Exception as e:
         logger.error(f"System: Error sorting node list: {e}")
         logger.debug(f"Node List1: {node_list1[:5]}\n")
         if multiple_interface:
-            logger.debug(f"FIX ME MULTI INTERFACE Node List2: {node_list2[:5]}\n")
+            logger.debug(
+                f"FIX ME MULTI INTERFACE Node List2: {node_list2[:5]}\n")
         node_list = ERROR_FETCHING_DATA
 
     try:
@@ -360,15 +386,16 @@ def get_node_list(nodeInt=1):
     except Exception as e:
         logger.error(f"System: Error creating node list: {e}")
         node_list = ERROR_FETCHING_DATA
-    
+
     return node_list
+
 
 def get_node_location(number, nodeInt=1, channel=0):
     interface = globals()[f'interface{nodeInt}']
     # Get the location of a node by its number from nodeDB on device
     latitude = latitudeValue
     longitude = longitudeValue
-    position = [latitudeValue,longitudeValue]
+    position = [latitudeValue, longitudeValue]
     lastheard = 0
     if interface.nodes:
         for node in interface.nodes.values():
@@ -378,12 +405,15 @@ def get_node_location(number, nodeInt=1, channel=0):
                         latitude = node['position']['latitude']
                         longitude = node['position']['longitude']
                     except Exception as e:
-                        logger.warning(f"System: Error getting location data for {number}")
-                    logger.debug(f"System: location data for {number} is {latitude},{longitude}")
-                    position = [latitude,longitude]
+                        logger.warning(
+                            f"System: Error getting location data for {number}")
+                    logger.debug(
+                        f"System: location data for {number} is {latitude},{longitude}")
+                    position = [latitude, longitude]
                     return position
                 else:
-                    logger.warning(f"System: No location data for {number} using default location")
+                    logger.warning(
+                        f"System: No location data for {number} using default location")
                     # request location data
                     # try:
                     #     logger.debug(f"System: Requesting location data for {number}")
@@ -396,7 +426,7 @@ def get_node_location(number, nodeInt=1, channel=0):
             return position
 
 
-def get_closest_nodes(nodeInt=1,returnCount=3):
+def get_closest_nodes(nodeInt=1, returnCount=3):
     interface = globals()[f'interface{nodeInt}']
     node_list = []
 
@@ -408,19 +438,21 @@ def get_closest_nodes(nodeInt=1,returnCount=3):
                     latitude = node['position']['latitude']
                     longitude = node['position']['longitude']
 
-                    #lastheard time in unix time
+                    # lastheard time in unix time
                     lastheard = node.get('lastHeard', 0)
-                    #if last heard is over 24 hours ago, ignore the node
+                    # if last heard is over 24 hours ago, ignore the node
                     if lastheard < (time.time() - 86400):
                         continue
 
                     # Calculate distance to node from config.ini location
-                    distance = round(geopy.distance.geodesic((latitudeValue, longitudeValue), (latitude, longitude)).m, 2)
-                    
+                    distance = round(geopy.distance.geodesic(
+                        (latitudeValue, longitudeValue), (latitude, longitude)).m, 2)
+
                     if (distance < sentry_radius):
                         if (nodeID not in [globals().get(f'myNodeNum{i}') for i in range(1, 10)]) and str(nodeID) not in sentryIgnoreList:
-                            node_list.append({'id': nodeID, 'latitude': latitude, 'longitude': longitude, 'distance': distance})
-                            
+                            node_list.append(
+                                {'id': nodeID, 'latitude': latitude, 'longitude': longitude, 'distance': distance})
+
                 except Exception as e:
                     pass
             # else:
@@ -432,15 +464,16 @@ def get_closest_nodes(nodeInt=1,returnCount=3):
             #         logger.error(f"System: Error requesting location data for {node['id']}. Error: {e}")
 
         # sort by distance closest
-        #node_list.sort(key=lambda x: (x['latitude']-latitudeValue)**2 + (x['longitude']-longitudeValue)**2)
+        # node_list.sort(key=lambda x: (x['latitude']-latitudeValue)**2 + (x['longitude']-longitudeValue)**2)
         node_list.sort(key=lambda x: x['distance'])
         # return the first 3 closest nodes by default
         return node_list[:returnCount]
     else:
-        logger.warning(f"System: No nodes found in closest_nodes on interface {nodeInt}")
+        logger.warning(
+            f"System: No nodes found in closest_nodes on interface {nodeInt}")
         return ERROR_FETCHING_DATA
 
-        
+
 def messageChunker(message):
     message_list = []
     if len(message) > MESSAGE_CHUNK_SIZE:
@@ -504,11 +537,13 @@ def messageChunker(message):
         # Calculate the total length of the message
         total_length = sum(len(chunk) for chunk in final_message_list)
         num_chunks = len(final_message_list)
-        logger.debug(f"System: Splitting #chunks: {num_chunks}, Total length: {total_length}")
+        logger.debug(
+            f"System: Splitting #chunks: {num_chunks}, Total length: {total_length}")
         return final_message_list
 
     return message
-        
+
+
 def send_message(message, ch, nodeid=0, nodeInt=1, bypassChuncking=False):
     # Send a message to a channel or DM
     interface = globals()[f'interface{nodeInt}']
@@ -531,76 +566,92 @@ def send_message(message, ch, nodeid=0, nodeInt=1, bypassChuncking=False):
             if nodeid == 0:
                 # Send to channel
                 if wantAck:
-                    logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + f"req.ACK " + f"Chunker{chunkOf} SendingChannel: " + CustomFormatter.white + m.replace('\n', ' '))
+                    logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + f"req.ACK " +
+                                f"Chunker{chunkOf} SendingChannel: " + CustomFormatter.white + m.replace('\n', ' '))
                     interface.sendText(text=m, channelIndex=ch, wantAck=True)
                 else:
-                    logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + f"Chunker{chunkOf} SendingChannel: " + CustomFormatter.white + m.replace('\n', ' '))
+                    logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red +
+                                f"Chunker{chunkOf} SendingChannel: " + CustomFormatter.white + m.replace('\n', ' '))
                     interface.sendText(text=m, channelIndex=ch)
             else:
                 # Send to DM
                 if wantAck:
-                    logger.info(f"Device:{nodeInt} " + CustomFormatter.red + f"req.ACK " + f"Chunker{chunkOf} Sending DM: " + CustomFormatter.white + m.replace('\n', ' ') + CustomFormatter.purple +\
-                             " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
-                    interface.sendText(text=m, channelIndex=ch, destinationId=nodeid, wantAck=True)
-                else:
-                    logger.info(f"Device:{nodeInt} " + CustomFormatter.red + f"Chunker{chunkOf} Sending DM: " + CustomFormatter.white + m.replace('\n', ' ') + CustomFormatter.purple +\
+                    logger.info(f"Device:{nodeInt} " + CustomFormatter.red + f"req.ACK " + f"Chunker{chunkOf} Sending DM: " + CustomFormatter.white + m.replace('\n', ' ') + CustomFormatter.purple +
                                 " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
-                    interface.sendText(text=m, channelIndex=ch, destinationId=nodeid)
+                    interface.sendText(text=m, channelIndex=ch,
+                                       destinationId=nodeid, wantAck=True)
+                else:
+                    logger.info(f"Device:{nodeInt} " + CustomFormatter.red + f"Chunker{chunkOf} Sending DM: " + CustomFormatter.white + m.replace('\n', ' ') + CustomFormatter.purple +
+                                " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
+                    interface.sendText(
+                        text=m, channelIndex=ch, destinationId=nodeid)
 
             # Throttle the message sending to prevent spamming the device
             if (message_list.index(m)+1) % 4 == 0:
                 time.sleep(responseDelay + 1)
                 if (message_list.index(m)+1) % 5 == 0:
-                    logger.warning(f"System: throttling rate Interface{nodeInt} on {chunkOf}")
-                
+                    logger.warning(
+                        f"System: throttling rate Interface{nodeInt} on {chunkOf}")
 
             # wait an amout of time between sending each split message
             time.sleep(splitDelay)
-    else: # message is less than MESSAGE_CHUNK_SIZE characters
+    else:  # message is less than MESSAGE_CHUNK_SIZE characters
         if nodeid == 0:
             # Send to channel
             if wantAck:
-                logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + "req.ACK " + "SendingChannel: " + CustomFormatter.white + message.replace('\n', ' '))
+                logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + "req.ACK " +
+                            "SendingChannel: " + CustomFormatter.white + message.replace('\n', ' '))
                 interface.sendText(text=message, channelIndex=ch, wantAck=True)
             else:
-                logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + "SendingChannel: " + CustomFormatter.white + message.replace('\n', ' '))
+                logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red +
+                            "SendingChannel: " + CustomFormatter.white + message.replace('\n', ' '))
                 interface.sendText(text=message, channelIndex=ch)
         else:
             # Send to DM
             if wantAck:
-                logger.info(f"Device:{nodeInt} " + CustomFormatter.red + "req.ACK " + "Sending DM: " + CustomFormatter.white + message.replace('\n', ' ') + CustomFormatter.purple +\
-                             " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
-                interface.sendText(text=message, channelIndex=ch, destinationId=nodeid, wantAck=True)
-            else:
-                logger.info(f"Device:{nodeInt} " + CustomFormatter.red + "Sending DM: " + CustomFormatter.white + message.replace('\n', ' ') + CustomFormatter.purple +\
+                logger.info(f"Device:{nodeInt} " + CustomFormatter.red + "req.ACK " + "Sending DM: " + CustomFormatter.white + message.replace('\n', ' ') + CustomFormatter.purple +
                             " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
-                interface.sendText(text=message, channelIndex=ch, destinationId=nodeid)
+                interface.sendText(text=message, channelIndex=ch,
+                                   destinationId=nodeid, wantAck=True)
+            else:
+                logger.info(f"Device:{nodeInt} " + CustomFormatter.red + "Sending DM: " + CustomFormatter.white + message.replace('\n', ' ') + CustomFormatter.purple +
+                            " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
+                interface.sendText(
+                    text=message, channelIndex=ch, destinationId=nodeid)
     return True
+
 
 def get_wikipedia_summary(search_term):
     wikipedia_search = wikipedia.search(search_term, results=3)
     wikipedia_suggest = wikipedia.suggest(search_term)
-    #wikipedia_aroundme = wikipedia.geosearch(location[0], location[1], results=3)
-    #logger.debug(f"System: Wikipedia Nearby:{wikipedia_aroundme}")
-    
+    # wikipedia_aroundme = wikipedia.geosearch(location[0], location[1], results=3)
+    # logger.debug(f"System: Wikipedia Nearby:{wikipedia_aroundme}")
+
     if len(wikipedia_search) == 0:
         logger.warning(f"System: No Wikipedia Results for:{search_term}")
         return ERROR_FETCHING_DATA
-    
+
     try:
-        logger.debug(f"System: Searching Wikipedia for:{search_term}, First Result:{wikipedia_search[0]}, Suggest Word:{wikipedia_suggest}")
-        summary = wikipedia.summary(search_term, sentences=wiki_return_limit, auto_suggest=False, redirect=True)
+        logger.debug(
+            f"System: Searching Wikipedia for:{search_term}, First Result:{wikipedia_search[0]}, Suggest Word:{wikipedia_suggest}")
+        summary = wikipedia.summary(
+            search_term, sentences=wiki_return_limit, auto_suggest=False, redirect=True)
     except wikipedia.DisambiguationError as e:
-        logger.warning(f"System: Disambiguation Error for:{search_term} trying {wikipedia_search[0]}")
-        summary = wikipedia.summary(wikipedia_search[0], sentences=wiki_return_limit, auto_suggest=True, redirect=True)
+        logger.warning(
+            f"System: Disambiguation Error for:{search_term} trying {wikipedia_search[0]}")
+        summary = wikipedia.summary(
+            wikipedia_search[0], sentences=wiki_return_limit, auto_suggest=True, redirect=True)
     except wikipedia.PageError as e:
-        logger.warning(f"System: Wikipedia Page Error for:{search_term} {e} trying {wikipedia_search[0]}")
-        summary = wikipedia.summary(wikipedia_search[0], sentences=wiki_return_limit, auto_suggest=True, redirect=True)
+        logger.warning(
+            f"System: Wikipedia Page Error for:{search_term} {e} trying {wikipedia_search[0]}")
+        summary = wikipedia.summary(
+            wikipedia_search[0], sentences=wiki_return_limit, auto_suggest=True, redirect=True)
     except Exception as e:
         logger.warning(f"System: Error with Wikipedia for:{search_term} {e}")
         return ERROR_FETCHING_DATA
-    
+
     return summary
+
 
 def messageTrap(msg):
     # Check if the message contains a trap word, this is the first filter for listning to messages
@@ -608,7 +659,7 @@ def messageTrap(msg):
 
     # Split Message on assumed words spaces m for m = msg.split(" ")
     # t in trap_list, built by the config and system.py not the user
-    message_list=msg.split(" ")
+    message_list = msg.split(" ")
     for m in message_list:
         for t in trap_list:
             # if word in message is in the trap list, return True
@@ -620,6 +671,7 @@ def messageTrap(msg):
             if m.endswith('?') and m[:-1].lower() == trap_list[t]:
                 return True
     return False
+
 
 def handleMultiPing(nodeID=0, deviceID=1):
     global multiPingList
@@ -642,7 +694,8 @@ def handleMultiPing(nodeID=0, deviceID=1):
 
                 # handle bufferTest
                 if type == '🎙TEST':
-                    buffer = ''.join(random.choice(['0', '1']) for i in range(maxBuffer))
+                    buffer = ''.join(random.choice(
+                        ['0', '1']) for i in range(maxBuffer))
                     # divide buffer by start_count and get resolution
                     resolution = maxBuffer // start_count
                     slice = resolution * count
@@ -660,7 +713,8 @@ def handleMultiPing(nodeID=0, deviceID=1):
                         count -= 1
 
                 # send the DM
-                send_message(f"🔂{count} {type}", channel_number, message_id_from, deviceID, bypassChuncking=True)
+                send_message(f"🔂{count} {type}", channel_number,
+                             message_id_from, deviceID, bypassChuncking=True)
                 time.sleep(responseDelay + 1)
                 if count < 2:
                     # remove the item from the list
@@ -682,7 +736,7 @@ def handleAlertBroadcast(deviceID=1):
         return False
     if clock.second > 17:
         return False
-    
+
     # check for alerts
     if wxAlertBroadcastEnabled:
         alertWx = alertBrodcastNOAA()
@@ -694,7 +748,8 @@ def handleAlertBroadcast(deviceID=1):
             alertUk = get_govUK_alerts()
         else:
             # default USA alerts
-            alertFema = getIpawsAlert(latitudeValue,longitudeValue, shortAlerts=True)
+            alertFema = getIpawsAlert(
+                latitudeValue, longitudeValue, shortAlerts=True)
 
     # format alert
     if alertWx:
@@ -729,7 +784,7 @@ def handleAlertBroadcast(deviceID=1):
             else:
                 send_message(ukAlert, emergencyAlertBroadcastCh, 0, deviceID)
             return True
-        
+
     # pause for 10 seconds
     time.sleep(10)
 
@@ -742,11 +797,13 @@ def handleAlertBroadcast(deviceID=1):
                 send_message(wxAlert, wxAlertBroadcastChannel, 0, deviceID)
             return True
 
+
 def onDisconnect(interface):
     global retry_int1, retry_int2, retry_int3, retry_int4, retry_int5, retry_int6, retry_int7, retry_int8, retry_int9
     rxType = type(interface).__name__
     if rxType in ['SerialInterface', 'TCPInterface', 'BLEInterface']:
-        identifier = interface.__dict__.get('devPath', interface.__dict__.get('hostname', 'BLE'))
+        identifier = interface.__dict__.get(
+            'devPath', interface.__dict__.get('hostname', 'BLE'))
         logger.critical(f"System: Lost Connection to Device {identifier}")
         for i in range(1, 10):
             if globals().get(f'interface{i}_enabled'):
@@ -755,6 +812,7 @@ def onDisconnect(interface):
                    (rxType == 'BLEInterface' and globals().get(f'interface{i}_type') == 'ble'):
                     globals()[f'retry_int{i}'] = True
                     break
+
 
 def exit_handler():
     # Close the interface and save the BBS messages
@@ -776,24 +834,30 @@ def exit_handler():
     logger.debug(f"System: Exiting")
     asyncLoop.stop()
     asyncLoop.close()
-    exit (0)
+    exit(0)
+
 
 # Telemetry Functions
 telemetryData = {}
+
+
 def initialize_telemetryData():
     telemetryData[0] = {f'interface{i}': 0 for i in range(1, 10)}
     telemetryData[0].update({f'lastAlert{i}': '' for i in range(1, 10)})
     for i in range(1, 10):
-        telemetryData[i] = {'numPacketsTx': 0, 'numPacketsRx': 0, 'numOnlineNodes': 0, 'numPacketsTxErr': 0, 'numPacketsRxErr': 0, 'numTotalNodes': 0}
+        telemetryData[i] = {'numPacketsTx': 0, 'numPacketsRx': 0, 'numOnlineNodes': 0,
+                            'numPacketsTxErr': 0, 'numPacketsRxErr': 0, 'numTotalNodes': 0}
+
 
 # indented to be called from the main loop
 initialize_telemetryData()
+
 
 def getNodeFirmware(nodeID=0, nodeInt=1):
     interface = globals()[f'interface{nodeInt}']
     # get the firmware version of the node
     # this is a workaround because .localNode.getMetadata spits out a lot of debug info which cant be suppressed
-    # Create a StringIO object to capture the 
+    # Create a StringIO object to capture the
     output_capture = io.StringIO()
     with contextlib.redirect_stdout(output_capture), contextlib.redirect_stderr(output_capture):
         interface.localNode.getMetadata()
@@ -802,6 +866,7 @@ def getNodeFirmware(nodeID=0, nodeInt=1):
         fwVer = console_output.split("firmware_version: ")[1].split("\n")[0]
         return fwVer
     return -1
+
 
 def displayNodeTelemetry(nodeID=0, rxNode=0, userRequested=False):
     interface = globals()[f'interface{rxNode}']
@@ -824,31 +889,40 @@ def displayNodeTelemetry(nodeID=0, rxNode=0, userRequested=False):
     totalOnlineNodes = telemetryData[rxNode]['numOnlineNodes']
 
     # get the telemetry data for a node
-    chutil = round(interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("deviceMetrics", {}).get("channelUtilization", 0), 1)
-    airUtilTx = round(interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("deviceMetrics", {}).get("airUtilTx", 0), 1)
-    uptimeSeconds = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("deviceMetrics", {}).get("uptimeSeconds", 0)
-    batteryLevel = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("deviceMetrics", {}).get("batteryLevel", 0)
-    voltage = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("deviceMetrics", {}).get("voltage", 0)
-    #numPacketsRx = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("localStats", {}).get("numPacketsRx", 0)
-    #numPacketsTx = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("localStats", {}).get("numPacketsTx", 0)
-    numTotalNodes = len(interface.nodes) 
-    
+    chutil = round(interface.nodes.get(decimal_to_hex(myNodeNum), {}).get(
+        "deviceMetrics", {}).get("channelUtilization", 0), 1)
+    airUtilTx = round(interface.nodes.get(decimal_to_hex(myNodeNum), {}).get(
+        "deviceMetrics", {}).get("airUtilTx", 0), 1)
+    uptimeSeconds = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get(
+        "deviceMetrics", {}).get("uptimeSeconds", 0)
+    batteryLevel = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get(
+        "deviceMetrics", {}).get("batteryLevel", 0)
+    voltage = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get(
+        "deviceMetrics", {}).get("voltage", 0)
+    # numPacketsRx = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("localStats", {}).get("numPacketsRx", 0)
+    # numPacketsTx = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("localStats", {}).get("numPacketsTx", 0)
+    numTotalNodes = len(interface.nodes)
+
     dataResponse = f"Telemetry:{rxNode}"
 
     # packet info telemetry
     dataResponse += f" numPacketsRx:{numPacketsRx} numPacketsRxErr:{numPacketsRxErr} numPacketsTx:{numPacketsTx} numPacketsTxErr:{numPacketsTxErr}"
 
     # Channel utilization and airUtilTx
-    dataResponse += " ChUtil%:" + str(round(chutil, 2)) + " AirTx%:" + str(round(airUtilTx, 2))
+    dataResponse += " ChUtil%:" + \
+        str(round(chutil, 2)) + " AirTx%:" + str(round(airUtilTx, 2))
 
     if chutil > 40:
-        logger.warning(f"System: High Channel Utilization {chutil}% on Device: {rxNode}")
+        logger.warning(
+            f"System: High Channel Utilization {chutil}% on Device: {rxNode}")
 
     if airUtilTx > 25:
-        logger.warning(f"System: High Air Utilization {airUtilTx}% on Device: {rxNode}")
+        logger.warning(
+            f"System: High Air Utilization {airUtilTx}% on Device: {rxNode}")
 
     # Number of nodes
-    dataResponse += " totalNodes:" + str(numTotalNodes) + " Online:" + str(totalOnlineNodes)
+    dataResponse += " totalNodes:" + \
+        str(numTotalNodes) + " Online:" + str(totalOnlineNodes)
 
     # Uptime
     uptimeSeconds = getPrettyTime(uptimeSeconds)
@@ -859,12 +933,17 @@ def displayNodeTelemetry(nodeID=0, rxNode=0, userRequested=False):
     dataResponse += f" Volt:{round(voltage, 1)}"
 
     if batteryLevel < 25:
-        logger.warning(f"System: Low Battery Level: {batteryLevel}{emji} on Device: {rxNode}")
+        logger.warning(
+            f"System: Low Battery Level: {batteryLevel}{emji} on Device: {rxNode}")
     elif batteryLevel < 10:
-        logger.critical(f"System: Critical Battery Level: {batteryLevel}{emji} on Device: {rxNode}")
+        logger.critical(
+            f"System: Critical Battery Level: {batteryLevel}{emji} on Device: {rxNode}")
     return dataResponse
 
+
 positionMetadata = {}
+
+
 def consumeMetadata(packet, rxNode=0):
     try:
         # keep records of recent telemetry data
@@ -875,7 +954,8 @@ def consumeMetadata(packet, rxNode=0):
 
         # TELEMETRY packets
         if packet_type == 'TELEMETRY_APP':
-            if debugMetadata: print(f"DEBUG TELEMETRY_APP: {packet}\n\n")
+            if debugMetadata:
+                print(f"DEBUG TELEMETRY_APP: {packet}\n\n")
             # get the telemetry data
             telemetry_packet = packet['decoded']['telemetry']
             if telemetry_packet.get('deviceMetrics'):
@@ -886,77 +966,90 @@ def consumeMetadata(packet, rxNode=0):
                 if localStats.get('numPacketsTx') is not None and localStats.get('numPacketsRx') is not None and localStats['numPacketsTx'] != 0:
                     # Assign the values to the telemetry dictionary
                     keys = [
-                        'numPacketsTx', 'numPacketsRx', 'numOnlineNodes', 
+                        'numPacketsTx', 'numPacketsRx', 'numOnlineNodes',
                         'numOfflineNodes', 'numPacketsTxErr', 'numPacketsRxErr', 'numTotalNodes']
-                    
+
                     for key in keys:
                         if localStats.get(key) is not None:
                             telemetryData[rxNode][key] = localStats.get(key)
-        
+
         # POSITION_APP packets
         if packet_type == 'POSITION_APP':
-            if debugMetadata: print(f"DEBUG POSITION_APP: {packet}\n\n")
+            if debugMetadata:
+                print(f"DEBUG POSITION_APP: {packet}\n\n")
             # get the position data
             keys = ['altitude', 'groundSpeed', 'precisionBits']
             position_data = packet['decoded']['position']
             try:
                 if nodeID not in positionMetadata:
                     positionMetadata[nodeID] = {}
-        
+
                 for key in keys:
                     positionMetadata[nodeID][key] = position_data.get(key, 0)
-        
+
                 # Keep the positionMetadata dictionary at 5 records
                 if len(positionMetadata) > 20:
                     # Remove the oldest entry
                     oldest_nodeID = next(iter(positionMetadata))
                     del positionMetadata[oldest_nodeID]
             except Exception as e:
-                logger.debug(f"System: POSITION_APP decode error: {e} packet {packet}")
+                logger.debug(
+                    f"System: POSITION_APP decode error: {e} packet {packet}")
 
         # WAYPOINT_APP packets
-        if packet_type ==  'WAYPOINT_APP':
-            if debugMetadata: print(f"DEBUG WAYPOINT_APP: {packet['decoded']['waypoint']}\n\n")
+        if packet_type == 'WAYPOINT_APP':
+            if debugMetadata:
+                print(
+                    f"DEBUG WAYPOINT_APP: {packet['decoded']['waypoint']}\n\n")
             # get the waypoint data
             waypoint_data = packet['decoded']
 
         # NEIGHBORINFO_APP
-        if packet_type ==  'NEIGHBORINFO_APP':
-            if debugMetadata: print(f"DEBUG NEIGHBORINFO_APP: {packet}\n\n")
+        if packet_type == 'NEIGHBORINFO_APP':
+            if debugMetadata:
+                print(f"DEBUG NEIGHBORINFO_APP: {packet}\n\n")
             # get the neighbor info data
-            neighbor_data = packet['decoded']
-        
+            # Use .get() instead of direct key access
+            neighbor_data = packet['decoded'].get('neighborinfo')
+
         # TRACEROUTE_APP
-        if packet_type ==  'TRACEROUTE_APP':
-            if debugMetadata: print(f"DEBUG TRACEROUTE_APP: {packet}\n\n")
+        if packet_type == 'TRACEROUTE_APP':
+            if debugMetadata:
+                print(f"DEBUG TRACEROUTE_APP: {packet}\n\n")
             # get the traceroute data
             traceroute_data = packet['decoded']
 
         # DETECTION_SENSOR_APP
-        if packet_type ==  'DETECTION_SENSOR_APP':
-            if debugMetadata: print(f"DEBUG DETECTION_SENSOR_APP: {packet}\n\n")
+        if packet_type == 'DETECTION_SENSOR_APP':
+            if debugMetadata:
+                print(f"DEBUG DETECTION_SENSOR_APP: {packet}\n\n")
             # get the detection sensor data
             detection_data = packet['decoded']
 
         # PAXCOUNTER_APP
-        if packet_type ==  'PAXCOUNTER_APP':
-            if debugMetadata: print(f"DEBUG PAXCOUNTER_APP: {packet}\n\n")
+        if packet_type == 'PAXCOUNTER_APP':
+            if debugMetadata:
+                print(f"DEBUG PAXCOUNTER_APP: {packet}\n\n")
             # get the paxcounter data
             paxcounter_data = packet['decoded']
 
         # REMOTE_HARDWARE_APP
-        if packet_type ==  'REMOTE_HARDWARE_APP':
-            if debugMetadata: print(f"DEBUG REMOTE_HARDWARE_APP: {packet}\n\n")
+        if packet_type == 'REMOTE_HARDWARE_APP':
+            if debugMetadata:
+                print(f"DEBUG REMOTE_HARDWARE_APP: {packet}\n\n")
             # get the remote hardware data
             remote_hardware_data = packet['decoded']
     except KeyError as e:
-        logger.critical(f"System: Error consuming metadata: {e} Device:{rxNode}")
+        logger.critical(
+            f"System: Error consuming metadata: {e} Device:{rxNode}")
         logger.debug(f"System: Error Packet = {packet}")
+
 
 def get_sysinfo(nodeID=0, deviceID=1):
     # Get the system telemetry data for return on the sysinfo command
     sysinfo = ''
-    stats = str(displayNodeTelemetry(nodeID, deviceID, userRequested=True)) + " 🤖👀" + str(len(seenNodes))
+    stats = str(displayNodeTelemetry(nodeID, deviceID,
+                userRequested=True)) + " 🤖👀" + str(len(seenNodes))
     if "numPacketsRx:0" in stats or stats == -1:
         return "Gathering Telemetry try again later⏳"
     # replace Telemetry with Int in string
@@ -964,20 +1057,22 @@ def get_sysinfo(nodeID=0, deviceID=1):
     sysinfo += f"📊{stats}"
     return sysinfo
 
+
 async def BroadcastScheduler():
     # handle schedule checks for the broadcast of messages
     while True:
         schedule.run_pending()
         await asyncio.sleep(1)
 
+
 async def handleSignalWatcher():
     global lastHamLibAlert
     # monitor rigctld for signal strength and frequency
     while True:
-        msg =  await signalWatcher()
+        msg = await signalWatcher()
         if msg != ERROR_FETCHING_DATA and msg is not None:
             logger.debug(f"System: Detected Alert from Hamlib {msg}")
-            
+
             # check we are not spammig the channel limit messages to once per minute
             if time.time() - lastHamLibAlert > 60:
                 lastHamLibAlert = time.time()
@@ -993,7 +1088,8 @@ async def handleSignalWatcher():
                                         send_message(msg, int(ch), 0, i)
                                         time.sleep(responseDelay)
                         else:
-                            logger.warning(f"System: antiSpam prevented Alert from Hamlib {msg}")
+                            logger.warning(
+                                f"System: antiSpam prevented Alert from Hamlib {msg}")
                 else:
                     if antiSpam and sigWatchBroadcastCh != publicChannel:
                         send_message(msg, int(sigWatchBroadcastCh), 0, 1)
@@ -1001,22 +1097,26 @@ async def handleSignalWatcher():
                         if multiple_interface:
                             for i in range(2, 10):
                                 if globals().get(f'interface{i}_enabled'):
-                                    send_message(msg, int(sigWatchBroadcastCh), 0, i)
+                                    send_message(
+                                        msg, int(sigWatchBroadcastCh), 0, i)
                                     time.sleep(responseDelay)
                     else:
-                        logger.warning(f"System: antiSpam prevented Alert from Hamlib {msg}")
+                        logger.warning(
+                            f"System: antiSpam prevented Alert from Hamlib {msg}")
 
         await asyncio.sleep(1)
         pass
+
 
 async def handleFileWatcher():
     global lastFileAlert
     # monitor the file system for changes
     while True:
-        msg =  await watch_file()
+        msg = await watch_file()
         if msg != ERROR_FETCHING_DATA and msg is not None:
-            logger.debug(f"System: Detected Alert from FileWatcher on file {file_monitor_file_path}")
-            
+            logger.debug(
+                f"System: Detected Alert from FileWatcher on file {file_monitor_file_path}")
+
             # check we are not spammig the channel limit messages to once per minute
             if time.time() - lastFileAlert > 60:
                 lastFileAlert = time.time()
@@ -1032,7 +1132,8 @@ async def handleFileWatcher():
                                         send_message(msg, int(ch), 0, i)
                                         time.sleep(responseDelay)
                         else:
-                            logger.warning(f"System: antiSpam prevented Alert from FileWatcher")
+                            logger.warning(
+                                f"System: antiSpam prevented Alert from FileWatcher")
                 else:
                     if antiSpam and file_monitor_broadcastCh != publicChannel:
                         send_message(msg, int(file_monitor_broadcastCh), 0, 1)
@@ -1040,13 +1141,16 @@ async def handleFileWatcher():
                         if multiple_interface:
                             for i in range(2, 10):
                                 if globals().get(f'interface{i}_enabled'):
-                                    send_message(msg, int(file_monitor_broadcastCh), 0, i)
+                                    send_message(
+                                        msg, int(file_monitor_broadcastCh), 0, i)
                                     time.sleep(responseDelay)
                     else:
-                        logger.warning(f"System: antiSpam prevented Alert from FileWatcher")
+                        logger.warning(
+                            f"System: antiSpam prevented Alert from FileWatcher")
 
         await asyncio.sleep(1)
         pass
+
 
 async def retry_interface(nodeID):
     global max_retry_count
@@ -1064,7 +1168,8 @@ async def retry_interface(nodeID):
 
     logger.debug(f"System: Retrying interface{nodeID} in 15 seconds")
     if max_retry_count == 0:
-        logger.critical(f"System: Max retry count reached for interface{nodeID}")
+        logger.critical(
+            f"System: Max retry count reached for interface{nodeID}")
         exit_handler()
 
     await asyncio.sleep(15)
@@ -1076,11 +1181,14 @@ async def retry_interface(nodeID):
             logger.debug(f"System: Retrying Interface{nodeID}")
             interface_type = globals()[f'interface{nodeID}_type']
             if interface_type == 'serial':
-                globals()[f'interface{nodeID}'] = meshtastic.serial_interface.SerialInterface(globals().get(f'port{nodeID}'))
+                globals()[f'interface{nodeID}'] = meshtastic.serial_interface.SerialInterface(
+                    globals().get(f'port{nodeID}'))
             elif interface_type == 'tcp':
-                globals()[f'interface{nodeID}'] = meshtastic.tcp_interface.TCPInterface(globals().get(f'hostname{nodeID}'))
+                globals()[f'interface{nodeID}'] = meshtastic.tcp_interface.TCPInterface(
+                    globals().get(f'hostname{nodeID}'))
             elif interface_type == 'ble':
-                globals()[f'interface{nodeID}'] = meshtastic.ble_interface.BLEInterface(globals().get(f'mac{nodeID}'))
+                globals()[f'interface{nodeID}'] = meshtastic.ble_interface.BLEInterface(
+                    globals().get(f'mac{nodeID}'))
             logger.debug(f"System: Interface{nodeID} Opened!")
             globals()[f'retry_int{nodeID}'] = False
     except Exception as e:
@@ -1088,6 +1196,8 @@ async def retry_interface(nodeID):
 
 handleSentinel_spotted = []
 handleSentinel_loop = 0
+
+
 async def handleSentinel(deviceID):
     global handleSentinel_spotted, handleSentinel_loop
     detectedNearby = ""
@@ -1105,11 +1215,13 @@ async def handleSentinel(deviceID):
                 break
             else:
                 return
-    
+
     if closest_nodes != ERROR_FETCHING_DATA and closest_nodes:
         if closest_nodes[0]['id'] is not None:
-            detectedNearby = get_name_from_number(closest_node, 'long', deviceID)
-            detectedNearby += ", " + get_name_from_number(closest_nodes[0]['id'], 'short', deviceID)
+            detectedNearby = get_name_from_number(
+                closest_node, 'long', deviceID)
+            detectedNearby += ", " + \
+                get_name_from_number(closest_nodes[0]['id'], 'short', deviceID)
             detectedNearby += ", " + str(closest_nodes[0]['id'])
             detectedNearby += ", " + decimal_to_hex(closest_nodes[0]['id'])
             detectedNearby += f" at {closest_distance}m"
@@ -1120,18 +1232,22 @@ async def handleSentinel(deviceID):
             if metadata.get('precisionBits') is not None:
                 resolution = metadata.get('precisionBits')
 
-        logger.warning(f"System: {detectedNearby} is close to your location on Interface{deviceID} Accuracy is {resolution}bits")
+        logger.warning(
+            f"System: {detectedNearby} is close to your location on Interface{deviceID} Accuracy is {resolution}bits")
         for i in range(1, 10):
             if globals().get(f'interface{i}_enabled'):
-                send_message(f"Sentry{deviceID}: {detectedNearby}", secure_channel, 0, i)
+                send_message(
+                    f"Sentry{deviceID}: {detectedNearby}", secure_channel, 0, i)
                 time.sleep(responseDelay + 1)
         if enableSMTP and email_sentry_alerts:
             for email in sysopEmails:
                 send_email(email, f"Sentry{deviceID}: {detectedNearby}")
         handleSentinel_loop = 0
-        handleSentinel_spotted.append({'id': closest_node, 'distance': closest_distance})
+        handleSentinel_spotted.append(
+            {'id': closest_node, 'distance': closest_distance})
     else:
         handleSentinel_loop += 1
+
 
 async def watchdog():
     global telemetryData, retry_int1, retry_int2, retry_int3, retry_int4, retry_int5, retry_int6, retry_int7, retry_int8, retry_int9
@@ -1146,7 +1262,8 @@ async def watchdog():
                 try:
                     firmware = getNodeFirmware(0, i)
                 except Exception as e:
-                    logger.error(f"System: communicating with interface{i}, trying to reconnect: {e}")
+                    logger.error(
+                        f"System: communicating with interface{i}, trying to reconnect: {e}")
                     globals()[f'retry_int{i}'] = True
 
                 if not globals()[f'retry_int{i}']:
@@ -1168,4 +1285,3 @@ async def watchdog():
                     await retry_interface(i)
                 except Exception as e:
                     logger.error(f"System: retrying interface{i}: {e}")
-


### PR DESCRIPTION
Fixed KeyError by using .get() for neighborinfo in [modules/system.py](https://github.com/SpudGunMan/meshing-around/blob/main/modules/system.py)

If some packets don’t contain the '[neighborinfo](https://meshtastic.org/docs/configuration/module/neighbor-info/)' field at all (for instance, if the device’s firmware doesn’t send it for certain packet types), then doing:

packet['decoded']['neighborinfo'] 

throws a KeyError.

Original error running in a mesh with nodes running the NEIGHBOR Module:

2025-01-20 12:02:49,319 | CRITICAL | System: Error processing packet: 'neighborInfo' Device:1
2025-01-20 12:02:49,320 |    DEBUG | System: Error Packet = {'from': 3663513172, 'to': 1, 'decoded': {'portnum': 'NEIGHBORINFO_APP', 'payload': b'\x08\xd4\x8c\xf3\xd2\r\x10\xd4\x8c\xf3\xd2\r\x18\xc0p"\x0b\x08\xdb\xdc\x92\xc8\x02\x15\x00\x00\xd0@"\x0b\x08\x84\xb1\xaf\x97\n\x15\x00\x00\xc0@"\x0b\x08\xd8\xdc\xe1\xa7\x05\x15\x00\x00\xe0?"\x0b\x08\x9c\xc1\xb0\xea\x0b\x15\x00\x00\xc0@"\x0b\x08\xc0\xf7\xde\x87\x05\x15\x00\x00\xd0@', 'bitfield': 1, 'neighborinfo': {'nodeId': 3663513172, 'lastSentById': 3663513172, 'nodeBroadcastIntervalSecs': 14400, 'neighbors': [{'nodeId': 688172635, 'snr': 6.5}, {'nodeId': 2733365380, 'snr': 6.0}, {'nodeId': 1425567320, 'snr': 1.75}, {'nodeId': 3175882908, 'snr': 6.0}, {'nodeId': 1358412736, 'snr': 6.5}], 'raw': node_id: 3663513172
last_sent_by_id: 3663513172
node_broadcast_interval_secs: 14400
neighbors {
  node_id: 688172635
  snr: 6.5
}
neighbors {
  node_id: 2733365380
  snr: 6
}
neighbors {
  node_id: 1425567320
  snr: 1.75
}
neighbors {
  node_id: 3175882908
  snr: 6
}
neighbors {
  node_id: 1358412736
  snr: 6.5
}
}}, 'id': 1052808561, 'rxTime': 1737392568, 'hopLimit': 4, 'priority': 'BACKGROUND', 'hopStart': 4, 'raw': from: 3663513172
to: 1
decoded {
  portnum: NEIGHBORINFO_APP
  payload: "\010\324\214\363\322\r\020\324\214\363\322\r\030\300p"\013\010\333\334\222\310\002\025\000\000\320@"\013\010\204\261\257\227\n\025\000\000\300@"\013\010\330\334\341\247\005\025\000\000\340?"\013\010\234\301\260\352\013\025\000\000\300@"\013\010\300\367\336\207\005\025\000\000\320@"
  bitfield: 1
}
id: 1052808561
rx_time: 1737392568
hop_limit: 4
priority: BACKGROUND
hop_start: 4
, 'fromId': '!da5cc654', 'toId': None}