### PR TITLE
change maxBuffer to 200

### DIFF
--- a/config.template
+++ b/config.template
@@ -266,6 +266,6 @@ MESSAGE_CHUNK_SIZE = 160
 # Request Acknowledgement of message OTA
 wantAck = False
 # Max limit buffer for radio testing. 233 is hard limit 2.5+ firmware
-maxBuffer = 220
+maxBuffer = 200
 
 


### PR DESCRIPTION
change maxBuffer to 200 by default, as this is the longest that the recent firmware allows.