### PR TITLE
Allow DMs to numeric short names

### DIFF
--- a/mesh_bot.py
+++ b/mesh_bot.py
@@ -804,7 +804,7 @@ def handle_bbspost(message, message_from_id, deviceID):
                 toNode = int(toNode.strip("!"),16)
             except ValueError as e:
                 toNode = 0
-        elif toNode.isalpha() or not toNode.isnumeric():
+        elif toNode.isalpha() or not toNode.isnumeric() or len(toNode) < 5:
             # try short name
             toNode = get_num_from_short_name(toNode, deviceID)
 


### PR DESCRIPTION
I have a node with a short name that's a 4 digit number. Logic in handle_bbspost makes it impossible to post a DM to this node using its short name, since the name gets interpreted as a node number instead, which posts a DM to a node that will never appear. Treat 4-or-less-digit numbers as short name instead of as node number. 