### PR TITLE
Allow chunker to consolidate lines when possible

### DIFF
--- a/modules/system.py
+++ b/modules/system.py
@@ -540,6 +540,15 @@ def messageChunker(message):
                 if current_chunk:
                     message_list.append(current_chunk)
 
+        # Consolidate any adjacent messages that can fit in a single chunk.
+        idx = 0
+        while idx < len(message_list) - 1:
+            if len(message_list[idx]) + len(message_list[idx+1]) < MESSAGE_CHUNK_SIZE:
+                message_list[idx] += '\n' + message_list[idx+1]
+                del message_list[idx+1]
+            else:
+                idx += 1
+
         # Ensure no chunk exceeds MESSAGE_CHUNK_SIZE
         final_message_list = []
         for chunk in message_list:


### PR DESCRIPTION
This allows the chunker to consolidate lines into significantly fewer messages in many cases without exceeding the max chunk size.

Without this change, the chunker will either emit all lines in one message (if it fits in a single chunk) or else each line will be in a separate message. This often creates a long series of short messages, which doesn't transmit as quickly or display as compact.

Instead, this consolidates as many lines as possible into each message, while being sure to stay within the chunk size limit. This should reduce the load on the mesh, and it's also more readable.