### PR TITLE
Fix possible message dropping due to throttling

### DIFF
--- a/modules/system.py
+++ b/modules/system.py
@@ -627,6 +627,10 @@ def send_message(message, ch, nodeid=0, nodeInt=1, bypassChuncking=False):
                 logger.info(f"Device:{nodeInt} " + CustomFormatter.red + "Sending DM: " + CustomFormatter.white + message.replace('\n', ' ') + CustomFormatter.purple +\
                             " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
                 interface.sendText(text=message, channelIndex=ch, destinationId=nodeid)
+
+            # wait an amout of time to prevent sending another message too quickly
+            time.sleep(splitDelay)
+
     return True
 
 def get_wikipedia_summary(search_term):


### PR DESCRIPTION
Trying to fix possible message being dropped due to firmware throttling (#162) 

12:01:00: User A sends "Ping" 
12:01:00: Meshbot sends "Pong" to User A
12:01:01: User B sends "Ping"
12:01:01: Meshbot sends "Pong" to User B. This message is too soon after the previous "Pong", is throttled by the node firmware and is dropped. User B never receives "Pong". 

This ensures we wait the specified time after sending ANY message, so we can't send two messages too quickly and have them dropped. 