### PR TITLE
News and bee seem to be independent from file monitor

### DIFF
--- a/mesh_bot.py
+++ b/mesh_bot.py
@@ -1465,10 +1465,10 @@ async def start_rx():
         logger.debug(f"System: File Monitor Enabled for {file_monitor_file_path}, broadcasting to channels: {file_monitor_broadcastCh}")
         if enable_runShellCmd:
             logger.debug(f"System: Shell Command monitor enabled")
-        if read_news_enabled:
-            logger.debug(f"System: File Monitor News Reader Enabled for {news_file_path}")
-        if bee_enabled:
-            logger.debug(f"System: File Monitor Bee Monitor Enabled for bee.txt")
+    if read_news_enabled:
+        logger.debug(f"System: News Reader Enabled for {news_file_path}")
+    if bee_enabled:
+        logger.debug(f"System: Bee Monitor Enabled for bee.txt")
     if wxAlertBroadcastEnabled:
         logger.debug(f"System: Weather Alert Broadcast Enabled on channels {wxAlertBroadcastChannel}")
     if emergencyAlertBrodcastEnabled:


### PR DESCRIPTION
I am not a python coder, so I might have gotten this wrong, but `fileMon.enable_read_news` and `general.bee` seem to be independent from the file monitor. The logging should reflect that.

Also in that case, `enable_read_news` and the corrensponding values should maybe have their own config section?

Finally as a beekeeper, I have to ask: "bee"? :-)