### PR TITLE
Add watch file directory and multi-channel sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Welcome to the Mesh Bot project! This feature-rich bot is designed to enhance yo
 - **NINA alerts for Germany**: Emergency Alerts from xrepository.de feed
 
 ### File Monitor Alerts
-- **File Monitor**: Monitor a flat/text file for changes, broadcast the contents of the message to the mesh channel.
+- **File Monitor**: Monitor a flat/text file for changes, broadcast the contents of the message to the mesh channel. Or monitor a directory, broadcast file contents and delete file.
 - **News File**: On request of news, the contents of the file are returned.
 
 ### Data Reporting
@@ -396,12 +396,13 @@ Some dev notes for ideas of use
 ```ini
 [fileMon]
 filemon_enabled = True
-file_path = alert.txt
-broadcastCh = 2,4
+file_path = alert.txt # Can be a directory. See lineChEnabled. Oldest file sent first, then file deleted.
+broadcastCh = 2,4 # Channels to broadcast file to. If only one listed, can be overidden with lineChEnabled.
 enable_read_news = False
 news_file_path = news.txt
 news_random_line = False # only return a single random line from the news file
 enable_runShellCmd = False # enables running of bash commands runShell.sh demo for sysinfo
+lineChEnabled = False # if True and file_path is a directory, start a message with "1A " to send to Channel 1 of node A. Channels 0-7 supported. Node A-Z at present ignored. (Note to future dev: Do not depend on USB port names, examine node ID to know which radio is connected.)
 ```
 
 #### Offline EAS

--- a/mesh_bot.py
+++ b/mesh_bot.py
@@ -1515,7 +1515,7 @@ async def start_rx():
     if radio_detection_enabled:
         logger.debug(f"System: Radio Detection Enabled using rigctld at {rigControlServerAddress} brodcasting to channels: {sigWatchBroadcastCh} for {get_freq_common_name(get_hamlib('f'))}")
     if file_monitor_enabled:
-        logger.debug(f"System: File Monitor Enabled for {file_monitor_file_path}, broadcasting to channels: {file_monitor_broadcastCh}")
+        logger.debug(f"System: File Monitor Enabled for {file_monitor_file_path}, broadcasting to channels: {file_monitor_broadcastCh}, lineChEnabled: {file_monitor_lineChEnabled}")
         if enable_runShellCmd:
             logger.debug(f"System: Shell Command monitor enabled")
         if read_news_enabled:

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -376,6 +376,7 @@ try:
     wantAck = config['messagingSettings'].getboolean('wantAck', False) # default False
     maxBuffer = config['messagingSettings'].getint('maxBuffer', 200) # default 200
     enableHopLogs = config['messagingSettings'].getboolean('enableHopLogs', False) # default False
+    file_monitor_lineChEnabled = config['fileMon'].getboolean('lineChEnabled', False) # default False
     debugMetadata = config['messagingSettings'].getboolean('debugMetadata', False) # default False
     DEBUGpacket = config['messagingSettings'].getboolean('DEBUGpacket', False) # default False
     noisyNodeLogging = config['messagingSettings'].getboolean('noisyNodeLogging', False) # default False

--- a/modules/system.py
+++ b/modules/system.py
@@ -1194,7 +1194,27 @@ async def handleFileWatcher():
                             logger.warning(f"System: antiSpam prevented Alert from FileWatcher")
                 else:
                     if antiSpam and file_monitor_broadcastCh != publicChannel:
-                        send_message(msg, int(file_monitor_broadcastCh), 0, 1)
+                        # Else not multiple channels configured, so check whether channel prefix should be used
+                        if file_monitor_lineChEnabled:
+                            prefix = re.match(r"^(\d)([A-Z]) ", msg)
+                            if prefix is not None and len(prefix.strip()) == 2:
+                                num_prefix = prefix[0]
+                                alpha_prefix = prefix[1]
+                            else:
+                                num_prefix = False
+                                alpha_prefix = False
+                        else:
+                            num_prefix = False
+                        if num_prefix:
+                        # if lineChEnabled and there is a numeric prefix, use that as channel number
+                        # there also will be an alpha prefix for the target node
+                            channel_num = num_prefix.group(0).trim()
+                            if( int(channel_num) > 7 ):
+                                channel_num = file_monitor_broadcastCh
+                        else:
+                            channel_num = file_monitor_broadcastCh
+                        send_message(msg, int(channel_num), 0, 1)
+ 
                         time.sleep(responseDelay)
                         if multiple_interface:
                             for i in range(2, 10):

--- a/pong_bot.py
+++ b/pong_bot.py
@@ -459,7 +459,7 @@ async def start_rx():
     if repeater_enabled and multiple_interface:
         logger.debug(f"System: Repeater Enabled for Channels: {repeater_channels}")
     if file_monitor_enabled:
-        logger.debug(f"System: File Monitor Enabled for {file_monitor_file_path}, broadcasting to channels: {file_monitor_broadcastCh}")
+        logger.debug(f"System: File Monitor Enabled for {file_monitor_file_path}, broadcasting to channels: {file_monitor_broadcastCh}, lineChEnabled: {file_monitor_lineChEnabled}")
     if read_news_enabled:
         logger.debug(f"System: File Monitor News Reader Enabled for {news_file_path}")
     if scheduler_enabled:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ geopy
 schedule
 wikipedia
 googlesearch-python
+pathlib


### PR DESCRIPTION
Instead of watching a text file for changes, you now can watch a directory.
Files with messages can be written to the directory.
Once a minute, directory will be checked, and the contents of the oldest file will be broadcast. File will be deleted.

Also, an option can be turned on which allows the specification of the desired Channel number in the format "1A " so alerts can be sent to different channels. The 'A' is for indicating the radio (for future expansion).