### PR TITLE
Adds data persistence loop and shared method to handle all persistence operations

### DIFF
--- a/config.template
+++ b/config.template
@@ -491,3 +491,9 @@ autoBanThreshold = 5
 apiThrottleValue = 20
 # Timeframe for offenses (in seconds)
 autoBanTimeframe = 3600
+
+[dataPersistence]
+# Enable or disable the data persistence loop service
+enabled = True
+# Interval in seconds for the persistence loop (how often to save data)
+interval = 300

--- a/mesh_bot.py
+++ b/mesh_bot.py
@@ -2272,8 +2272,11 @@ async def main():
         # Create core tasks
         tasks.append(asyncio.create_task(start_rx(), name="mesh_rx"))
         tasks.append(asyncio.create_task(watchdog(), name="watchdog"))
-        
+
         # Add optional tasks
+        if my_settings.dataPersistence_enabled:
+            tasks.append(asyncio.create_task(dataPersistenceLoop(), name="data_persistence"))
+
         if my_settings.file_monitor_enabled:
             tasks.append(asyncio.create_task(handleFileWatcher(), name="file_monitor"))
         

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -507,6 +507,10 @@ try:
     autoBanThreshold = config['messagingSettings'].getint('autoBanThreshold', 5) # default 5 offenses
     autoBanTimeframe = config['messagingSettings'].getint('autoBanTimeframe', 3600) # default 1 hour in seconds
     apiThrottleValue = config['messagingSettings'].getint('apiThrottleValue', 20) # default 20 requests
+
+    # data persistence settings
+    dataPersistence_enabled = config.getboolean('dataPersistence', 'enabled', fallback=True) # default True
+    dataPersistence_interval = config.getint('dataPersistence', 'interval', fallback=300) # default 300 seconds (5 minutes)
 except Exception as e:
     print(f"System: Error reading config file: {e}")
     print("System: Check the config.ini against config.template file for missing sections or values.")

--- a/modules/system.py
+++ b/modules/system.py
@@ -2425,8 +2425,36 @@ async def watchdog():
             load_bbsdm()
             load_bbsdb()
 
+def saveAllData():
+    try:
+        # Save BBS data if enabled
+        if bbs_enabled:
+            save_bbsdb()
+            save_bbsdm()
+            logger.debug("Persistence: BBS data saved")
+
+        # Save leaderboard data if enabled
+        if logMetaStats:
+            saveLeaderboard()
+            logger.debug("Persistence: Leaderboard data saved")
+
+        # Save ban list
+        save_bbsBanList()
+        logger.debug("Persistence: Ban list saved")
+
+        logger.info("Persistence: Save completed")
+    except Exception as e:
+        logger.error(f"Persistence: Save error: {e}")
+
+async def dataPersistenceLoop():
+    """Data persistence service loop for periodic data saving"""
+    logger.debug("Persistence: Loop started")
+    while True:
+        await asyncio.sleep(dataPersistence_interval)
+        saveAllData()
+
 def exit_handler():
-    # Close the interface and save the BBS messages
+    # Close the interface and save all data
     logger.debug(f"System: Closing Autoresponder")
     try:
         logger.debug(f"System: Closing Interface1")
@@ -2438,12 +2466,9 @@ def exit_handler():
                     globals()[f'interface{i}'].close()
     except Exception as e:
         logger.error(f"System: closing: {e}")
-    if bbs_enabled:
-        save_bbsdb()
-        save_bbsdm()
-        logger.debug(f"System: BBS Messages Saved")
-    if logMetaStats:
-        saveLeaderboard()
+
+    saveAllData()
+
     logger.debug(f"System: Exiting")
     asyncLoop.stop()
     asyncLoop.close()

--- a/pong_bot.py
+++ b/pong_bot.py
@@ -671,8 +671,11 @@ async def main():
         # Create core tasks
         tasks.append(asyncio.create_task(start_rx(), name="mesh_rx"))
         tasks.append(asyncio.create_task(watchdog(), name="watchdog"))
-        
+
         # Add optional tasks
+        if my_settings.dataPersistence_enabled:
+            tasks.append(asyncio.create_task(dataPersistenceLoop(), name="data_persistence"))
+
         if my_settings.file_monitor_enabled:
             tasks.append(asyncio.create_task(handleFileWatcher(), name="file_monitor"))
         


### PR DESCRIPTION
Adds a new background service for persistence operations.

Service can be disabled entirely with config or a custom interval set.

This allows docker containers to properly persist state on a schedule.

resolves #280 