### PR TITLE
feat: migrate mesh_bot to MeshCore with async bbslink support

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,197 @@
+# MeshCore Bot — Command Testing Checklist
+
+Testing on MeshCore (Heltec V3, serial `/dev/ttyUSB0`).  
+Status: ✅ Working | ❌ Broken | ⚠️ Partial | ⬜ Not tested | 🚫 Disabled in config
+
+Send commands as DMs to the bot node. Check `data/syslog.txt` for errors.
+
+---
+
+## Core / Identity
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| ✅ | `ping` | Returns pong with hop count / SNR |
+| ✅ | `ack` | Returns ACK-ACK |
+| ✅ | `cq` / `cqcq` / `cqcqcq` | Was showing `000000000000` as bot name — fixed to use `mc.self_info.name` |
+| ✅ | `test` / `testing` | Returns random testing phrase |
+| ✅ | `pong` | Returns PING!! |
+| ✅ | `whoami` | Shows your name, pubkey prefix, hop/SNR — needs contact to have advertised |
+| ✅ | `whois <partial>` | Prefix search — 1 match = 1 reply, multiple matches = 1 DM per match |
+| ⬜ | `📍` | Alias for whoami |
+| ⬜ | `cmd` / `cmd?` | List available commands |
+| ⬜ | `echo <text>` | Echoes back the message |
+
+---
+
+## Location
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| ✅ | `whereami` | Returns **sender's** GPS location — requires sender node to have GPS; falls back to "no GPS" message |
+| ⬜ | `howfar` | Distance you've traveled since last call — requires sender to have `adv_lat`/`adv_lon` in contact cache |
+| ⬜ | `howfar reset` | Reset your starting point |
+| ⬜ | `howtall` | Elevation diff from bot location |
+| ⬜ | `map` | Returns a map link |
+
+---
+
+## Node Info / Status
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| ⬜ | `sitrep` / `lheard` | Recently heard nodes |
+| ⬜ | `sysinfo` | Bot uptime, contact count, session DM count |
+| ⬜ | `leaderboard` | Best/worst RF signal and most active node — populated after receiving DMs with RSSI |
+| ⬜ | `history` | Message history |
+| ⬜ | `messages` | Channel message history |
+| ⬜ | `motd` | Message of the day (`motd =` in `[general]`) |
+| ⬜ | `path` | Repeater path + estimated distance for last received message |
+
+---
+
+## Weather
+
+Location: sender GPS first (from contact cache), fallback to bot lat/lon (`lat`/`lon` in `[location]`).  
+Outside US: set `UseMeteoWxAPI = True` in `[location]` — currently **True** ✅
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| ✅ | `wx` | `[location] UseMeteoWxAPI = True` ✅ |
+| ⬜ | `wxc` | Weather in Celsius — same API as `wx` |
+| ⬜ | `wxa` / `wxalert` | Weather alerts |
+| 🚫 | `mwx` | Requires `[location] coastalEnabled = True` — currently **not set** (defaults False) |
+| 🚫 | `tide` | Requires `[location] coastalEnabled = True` — currently **not set** (defaults False) |
+| ⬜ | `riverflow` | River flow data — uses bot lat/lon |
+| ⬜ | `moon` | Moon phase |
+| ⬜ | `sun` | Sunrise/sunset |
+
+---
+
+## Solar / HF Conditions
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| ⬜ | `hfcond` | HF band conditions |
+| ⬜ | `solar` | Solar/space weather |
+| ⬜ | `satpass` | Satellite pass times |
+| ⬜ | `earthquake` | Recent earthquakes |
+| ⬜ | `valert` | Volcano alerts |
+
+---
+
+## Games
+
+Config in `[games]` section. Missing keys default to `True` except `quiz` (defaults `False`).
+
+| Status | Command | Config flag | Notes |
+|--------|---------|-------------|-------|
+| ✅ | `blackjack` | `blackjack = True` ✅ | Card game |
+| ✅ | `videopoker` | `videopoker = True` ✅ | Poker game |
+| ✅ | `dopewars` | `dopewars = True` ✅ | Drug market sim |
+| ✅ | `lemonstand` | `lemonade = True` ✅ | Lemonade stand sim |
+| ⬜ | `golfsim` | `golfSim` not in config → default **True** | Golf game |
+| ⬜ | `mastermind` | `mastermind` not in config → default **True** | Code-guessing game |
+| ⬜ | `hangman` | `hangman` not in config → default **True** | Word game |
+| ⬜ | `tictactoe` / `tic-tac-toe` | `tictactoe` not in config → default **True** | Board display stubbed; text board doesn't render over mesh |
+| 🚫 | `quiz` / `q: <answer>` | `quiz` not in config → default **False** | Enable with `[games] quiz = True` |
+| ⬜ | `battleship` | `battleShip` not in config → default **True** | Naval game |
+| ⬜ | `hamtest` | `hamtest` not in config → default **True** | Ham radio practice exam |
+| ⬜ | `games` | — | List games |
+
+---
+
+## BBS (`[bbs] enabled = True` ✅)
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| ⬜ | `bbslist` | List all public messages |
+| ⬜ | `bbspost $subject #body` | Post a public message |
+| ⬜ | `bbspost @ShortName #body` | Leave an offline DM for another node |
+| ⬜ | `bbsread #<id>` | Read a message by ID |
+| ⬜ | `bbsdelete #<id>` | Delete your own message (or any if admin) |
+| ⬜ | `bbshelp` | BBS command help |
+| ⬜ | `bbsinfo` | Message count and pending DMs |
+| ⬜ | `bbsack` / `bbslink` | BBS sync between two bots — requires `[bbs] bbs_link_enabled = True` |
+| ⬜ | `bannode add/remove/list <prefix>` | Admin only — ban a node from BBS |
+
+---
+
+## Messaging / SMS / Email
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| 🚫 | `sms: <node> <msg>` | Requires `[smtp] enablesmtp = True` — currently **False** |
+| 🚫 | `setsms <number>` | Same SMTP requirement |
+| 🚫 | `clearsms` | Same SMTP requirement |
+| 🚫 | `email: <addr> <msg>` | Requires `[smtp] enablesmtp = True` — currently **False** |
+| 🚫 | `setemail <addr>` | Same SMTP requirement |
+
+---
+
+## Info Lookups
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| 🚫 | `wiki <topic>` | No `[wiki]` section in config.ini |
+| ⬜ | `readrss <url>` | RSS feed reader |
+| ⬜ | `latest` / `readnews` | News headlines |
+| 🚫 | `dx` | No `[dxspot]` section in config.ini |
+| ⬜ | `rlist` | Repeater lookup |
+| ⬜ | `verse` | Bible verse |
+| ⬜ | `🐝` | Bee file |
+| 🚫 | `joke` | `[general] DadJokes = False` — set to `True` to enable |
+
+---
+
+## AI / LLM
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| 🚫 | `ask: <question>` | No `[llm]` section in config.ini |
+| 🚫 | `askai <question>` | No `[llm]` section in config.ini |
+
+---
+
+## Emergency
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| 🚫 | `911` / `112` / `999` | `[emergencyHandler] enabled = False` |
+| 🚫 | `emergency` / `fire` / `police` / `ambulance` / `rescue` | `[emergencyHandler] enabled = False` |
+| 🚫 | `ea` / `ealert` | `[emergencyHandler] enabled = False` |
+
+---
+
+## Checklist / Inventory (disabled in config)
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| 🚫 | `checkin` / `checkout` / `checklist` | `[checklist] enabled = False` |
+| 🚫 | `item` / `itemadd` / `itemlist` / etc. | `[inventory] enabled = False` |
+| 🚫 | `cart` / `cartadd` / `cartbuy` / etc. | `[inventory] enabled = False` |
+
+---
+
+## Misc
+
+| Status | Command | Notes |
+|--------|---------|-------|
+| ⬜ | `globalthermonuclearwar` | Easter egg |
+| ⬜ | `chess` | Redirects to external game |
+| ⬜ | `🔔` | Alert bell |
+| ⬜ | `x: <cmd>` | Shell command exec (sysop only) |
+
+---
+
+## Known Issues / Notes
+
+- **`sysinfo`** — now shows uptime, contact count, and session DM count (Meshtastic TX/RX packet counters were always 0 and have been removed).
+- **`tictactoe` board** — visual board display is stubbed; the raw-bytes draw method isn't ported yet.
+- **`howfar`** — requires the sender's node to have GPS and to have advertised position (`adv_lat`/`adv_lon` in contact). If sender has no GPS → returns "No GPS location available".
+- **`whereami`** — returns sender's GPS, not the bot's location. Returns error if sender has no GPS.
+- **`leaderboard`** — only Best RF, Worst RF (from RSSI on RX_LOG_DATA events), and Most Messages (DM count) are populated in MeshCore. Meshtastic telemetry fields (battery, voltage, etc.) remain empty.
+- **`mwx` / `tide`** — gated by `[location] coastalEnabled = True`; not set in config so these commands are not registered.
+- **Contact names** — populated from `CONTACTS` / `NEW_CONTACT` events at startup. If a node hasn't advertised yet, its pubkey prefix is used as the name.
+- **Scheduler** — `[scheduler] enabled = False`; `send_message()` calls inside it are not `await`-ed (not urgent while disabled).
+- **Weather location** — all weather commands use sender GPS first (from contact cache `adv_lat`/`adv_lon`), falling back to bot `lat`/`lon` from `[location]`. Outside US requires `UseMeteoWxAPI = True`.

--- a/config.template
+++ b/config.template
@@ -188,8 +188,10 @@ bbs_ban_list =
 bbs_admin_list = 
 # enable bbs synchronization with other nodes
 bbslink_enabled = False
-# list of whitelisted nodes numbers ex: 2813308004,4258675309 empty list allows all
-bbslink_whitelist =
+# Peer BBS bots to sync with (comma-separated pubkey prefixes, 12-char hex from MeshCore).
+# Also acts as the inbound whitelist — only these nodes may initiate sync with this bot.
+# Leave empty to allow any node to sync (open mode).
+bbslink_peers =
 # enable API script access (increases disk i/o)
 bbsAPI_enabled = False 
 

--- a/mesh_bot.py
+++ b/mesh_bot.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python3
 # Meshtastic Autoresponder MESH Bot
 # K7MHI Kelly Keeton 2025
-try:
-    from pubsub import pub
-except ImportError:
-    print(f"Important dependencies are not met, try install.sh\n\n Did you mean to './launch.sh mesh' using a virtual environment.")
-    exit(1)
+from meshcore import EventType
 
 import asyncio
+import math
 import time # for sleep, get some when you can :)
 import random
 from datetime import datetime
 from modules.log import logger, CustomFormatter, msgLogger, getPrettyTime
 import modules.settings as my_settings
 from modules.system import *
+from modules.system import _contacts, get_bot_keys
 
 # list of commands to remove from the default list for DM only
 restrictedCommands = ["blackjack", "videopoker", "dopewars", "lemonstand", "golfsim", "mastermind", "hangman", "hamtest", "tictactoe", "tic-tac-toe", "quiz", "q:", "survey", "s:", "battleship"]
@@ -32,11 +30,9 @@ def auto_response(message, snr, rssi, hop, pkiStatus, message_from_id, channel_n
     "askai": lambda: handle_llm(message_from_id, channel_number, deviceID, message, publicChannel),
     "bannode": lambda: handle_bbsban(message, message_from_id, isDM),
     "battleship": lambda: handleBattleship(message, message_from_id, deviceID),
-    "bbsack": lambda: bbs_sync_posts(message, message_from_id, deviceID),
     "bbsdelete": lambda: handle_bbsdelete(message, message_from_id),
     "bbshelp": bbs_help,
     "bbsinfo": lambda: get_bbs_stats(),
-    "bbslink": lambda: bbs_sync_posts(message, message_from_id, deviceID),
     "bbslist": bbs_list_messages,
     "bbspost": lambda: handle_bbspost(message, message_from_id, deviceID),
     "bbsread": lambda: handle_bbsread(message),
@@ -125,6 +121,7 @@ def auto_response(message, snr, rssi, hop, pkiStatus, message_from_id, channel_n
     "whereami": lambda: handle_whereami(message_from_id, deviceID, channel_number),
     "whoami": lambda: handle_whoami(message_from_id, deviceID, hop, snr, rssi, pkiStatus),
     "whois": lambda: handle_whois(message, deviceID, channel_number, message_from_id),
+    "path": lambda: handle_path(message_from_id, deviceID),
     "wiki": lambda: handle_wiki(message, isDM),
     "wx": lambda: handle_wxc(message_from_id, deviceID, 'wx'),
     "wxa": lambda: handle_wxalert(message_from_id, deviceID, message),
@@ -243,7 +240,7 @@ def check_and_play_game(tracker, message_from_id, message_string, rxNode, channe
             if tracker[i].get(last_played_key) > (time.time() - my_settings.GAMEDELAY):
                 if llm_enabled:
                     logger.debug(f"System: LLM Disabled for {message_from_id} for duration of {game_name}")
-                send_message(handle_game_func(message_string, message_from_id, rxNode), channel_number, message_from_id, rxNode)
+                asyncio.ensure_future(send_message(handle_game_func(message_string, message_from_id, rxNode), channel_number, message_from_id, rxNode))
                 return True, game_name
     return False, "None"
     
@@ -273,26 +270,18 @@ def handle_ping(message_from_id, deviceID,  message, hop, snr, rssi, isDM, chann
         msg = random.choice(["✋ACK-ACK!\n", "✋Ack to you!\n"])
         type = "✋ACK"
     elif "cqcq" in message.lower() or "cq" in message.lower() or "cqcqcq" in message.lower():
-        myname = get_name_from_number(myNodeNum, 'short', deviceID)
-        msg = f"QSP QSL OM DE  {myname}   K\n"
+        mc = get_interface(deviceID)
+        self_info = (mc.self_info or {}) if mc else {}
+        myname = self_info.get('name') or myNodeNum or '?'
+        msg = f"QSP QSL OM DE {myname} K\n"
     else:
         msg = "🔊 Can you hear me now?"
 
-    # append SNR/RSSI or hop info
-    if hop.startswith("Gateway") or hop.startswith("MQTT"):
-        msg += " [GW]"
-    elif hop.startswith("Direct"):
-        msg += " [RF]"
-    else:
-        #flood
-        msg += " [F]"
-    
-    if (float(snr) != 0 or float(rssi) != 0) and "Hop" not in hop:
+    # append SNR/RSSI or hop info (MeshCore: everything is RF, show hops or signal)
+    if "Hop" in hop:
+        msg += f"\n{hop}"
+    elif float(snr) != 0 or float(rssi) != 0:
         msg += f"\nSNR:{snr} RSSI:{rssi}"
-    elif "Hop" in hop:
-        # janky, remove the words Gateway or MQTT if present
-        hop = hop.replace("Gateway", "").replace("Direct", "").replace("MQTT", "").strip()
-        msg += f"\n{hop} "
 
     if "@" in message:
         msg = msg + " @" + message.split("@")[1]
@@ -381,7 +370,7 @@ def handle_emergency(message_from_id, deviceID, message):
         nodeInfo = f"{get_name_from_number(message_from_id, 'short', deviceID)} detected by {get_name_from_number(myNodeNum, 'short', deviceID)} lastGPS {nodeLocation[0]}, {nodeLocation[1]}"
         msg = f"🔔🚨Intercepted Possible Emergency Assistance needed for: {nodeInfo}"
         # alert the emergency_responder_alert_channel
-        send_message(msg, my_settings.emergency_responder_alert_channel, 0, my_settings.emergency_responder_alert_interface)
+        asyncio.ensure_future(send_message(msg, my_settings.emergency_responder_alert_channel, 0, my_settings.emergency_responder_alert_interface))
         logger.warning(f"System: {message_from_id} Emergency Assistance Requested in {message}")
         # send the message out via email/sms
         if my_settings.enableSMTP:
@@ -430,7 +419,7 @@ def handle_echo(message, message_from_id, deviceID, isDM, channel_number):
         # Send echo to specified channel/device
         logger.debug(f"System: Admin Echo to channel {target_channel} device {target_device} message: {msg_to_echo}")
         time.sleep(splitDelay) # throttle for 2x send
-        send_message(msg_to_echo, target_channel, 0, target_device)
+        asyncio.ensure_future(send_message(msg_to_echo, target_channel, 0, target_device))
         time.sleep(splitDelay) # throttle for 2x send
         return f"🐬echoed to channel {target_channel} device {target_device}"
 
@@ -669,10 +658,10 @@ def handle_llm(message_from_id, channel_number, deviceID, message, publicChannel
         if not any(node['nodeID'] == message_from_id and node['welcome'] == True for node in seenNodes):
             if (channel_number == publicChannel and my_settings.antiSpam) or my_settings.useDMForResponse:
                 # send via DM
-                send_message(my_settings.welcome_message, 0, message_from_id, deviceID)
+                asyncio.ensure_future(send_message(my_settings.welcome_message, 0, message_from_id, deviceID))
             else:
                 # send via channel
-                send_message(my_settings.welcome_message, channel_number, 0, deviceID)
+                asyncio.ensure_future(send_message(my_settings.welcome_message, channel_number, 0, deviceID))
             # mark the node as welcomed
             for node in seenNodes:
                 if node['nodeID'] == message_from_id:
@@ -704,11 +693,11 @@ def handle_llm(message_from_id, channel_number, deviceID, message, publicChannel
     if msg != '':
         if (channel_number == publicChannel and my_settings.antiSpam) or my_settings.useDMForResponse:
             # send via DM
-            send_message(msg, 0, message_from_id, deviceID)
+            asyncio.ensure_future(send_message(msg, 0, message_from_id, deviceID))
         else:
             # send via channel
-            send_message(msg, channel_number, 0, deviceID)
-    
+            asyncio.ensure_future(send_message(msg, channel_number, 0, deviceID))
+
     start = time.time()
 
     #response = asyncio.run(llm_query(user_input, message_from_id))
@@ -741,7 +730,7 @@ def handleDopeWars(message, nodeID, rxNode):
         dwPlayerTracker.append(player)
         msg = 'Welcome to 💊Dope Wars💉 You have ' + str(total_days) + ' days to make as much 💰 as possible! '
         high_score = getHighScoreDw()
-        msg += 'The High Score is $' + "{:,}".format(high_score.get('cash')) + ' by user ' + get_name_from_number(high_score.get('userID'), 'short', rxNode) + '\n'
+        msg += 'The High Score is $' + "{:,}".format(high_score.get('cash')) + ' by ' + get_name_from_number(high_score.get('userID'), 'long', rxNode) + '\n'
         msg += playDopeWars(nodeID, message)
     elif player:
         # Update last_played and cmd for the player
@@ -1170,12 +1159,12 @@ def handleBattleship(message, nodeID, deviceID):
             "session_id": session.session_id
         })
         p1_short_name = get_short_name(session.player1_id)
-        send_message(
+        asyncio.ensure_future(send_message(
             f"{p1_short_name}, your opponent {short_name} has joined the game! It's their turn first.",
             0,  # channel 0 for DM
             session.player1_id,  # recipient nodeID
             deviceID
-        )
+        ))
         time.sleep(splitDelay)  # slight delay to avoid message overlap
         return "You joined the game! It's your turn. Enter your move (e.g., 'B4')."
 
@@ -1207,12 +1196,12 @@ def handleBattleship(message, nodeID, deviceID):
             # Only notify if it's not the player who just moved
             if next_player_id != nodeID:
                 next_player_short_name = get_short_name(next_player_id)
-                send_message(
+                asyncio.ensure_future(send_message(
                     f"{next_player_short_name}, it's your turn in Battleship! Enter your move (e.g., 'B4').",
                     0,  # channel 0 for DM
                     next_player_id,
                     deviceID
-                )
+                ))
                 time.sleep(splitDelay)  # slight delay to avoid message overlap
 
     return response
@@ -1271,7 +1260,7 @@ def quizHandler(message, nodeID, deviceID):
         # broadcast message to all players if user is in bbs_admin_list and msg is a dict with 'message' key
         if isinstance(msg, dict) and str(nodeID) in bbs_admin_list and 'message' in msg:
             for player_id in quizGamePlayer.players:
-                send_message(msg['message'], 0, player_id, deviceID)
+                asyncio.ensure_future(send_message(msg['message'], 0, player_id, deviceID))
             msg = f"Message sent to {len(quizGamePlayer.players)} players"
 
         return msg
@@ -1412,27 +1401,23 @@ def handle_bbspost(message, message_from_id, deviceID):
         elif not "example:" in message:
             return "example: bbspost $subject #✉️message"
     elif "@" in message and not "example:" in message:
-        toNode = message.split("@")[1].split("#")[0]
-        toNode = toNode.rstrip()
-        if toNode.startswith("!") and len(toNode) == 9:
-            # mesh !hex
-            try:
-                toNode = int(toNode.strip("!"),16)
-            except ValueError as e:
-                toNode = 0
-        elif toNode.isalpha() or not toNode.isnumeric() or len(toNode) < 5:
-            # try short name
-            toNode = get_num_from_short_name(toNode, deviceID)
+        query = message.split("@")[1].split("#")[0].rstrip()
+        matches = find_contacts_by_name(query)
+        if len(matches) == 0:
+            return f"Node '{query}' not found — they must have messaged the bot first"
+        elif len(matches) > 1:
+            lines = ["Multiple nodes found, be more specific:"]
+            for prefix, name in matches[:5]:
+                lines.append(f"{name} ({prefix[:6].upper()})")
+            return "\n".join(lines)
+        toNode = matches[0][0]
 
         if "#" in message:
-            if toNode == 0:
-                return "Node not found " + message.split("@")[1].split("#")[0]
-            body = message.split("#", 1)[1]
-            body = body.rstrip()
-            logger.info(f"System: BBS Post DM to: {toNode} Body: {body}")
+            body = message.split("#", 1)[1].rstrip()
+            logger.info(f"System: BBS Post DM to: {toNode} ({matches[0][1]}) Body: {body}")
             return bbs_post_dm(toNode, body, message_from_id)
         else:
-            return "example: bbspost @nodeNumber/ShortName/!hex #✉️message"
+            return "example: bbspost @name #✉️message"
     elif not "example:" in message:
         return "example: bbspost $subject #✉️message, or bbspost @node #✉️message"
 
@@ -1602,12 +1587,15 @@ def handle_history(message, nodeid, deviceID, isDM, lheard=False):
     return msg
 
 def handle_whereami(message_from_id, deviceID, channel_number):
-    location = get_node_location(message_from_id, deviceID, channel_number)
-    # check api_throttle
     check_throttle = api_throttle(message_from_id, deviceID, apiName='whereami')
     if check_throttle:
         return check_throttle
-    return where_am_i(str(location[0]), str(location[1]))
+    contact = _contacts.get(str(message_from_id), {})
+    lat = contact.get('lat')
+    lon = contact.get('lon')
+    if lat is None or lon is None or (lat == 0.0 and lon == 0.0):
+        return my_settings.NO_DATA_NOGPS
+    return where_am_i(str(round(lat, 4)), str(round(lon, 4)))
 
 def handle_repeaterQuery(message_from_id, deviceID, channel_number):
     location = get_node_location(message_from_id, deviceID, channel_number)
@@ -1636,67 +1624,117 @@ def handle_moon(message_from_id, deviceID, channel_number, vox=False):
 
 def handle_whoami(message_from_id, deviceID, hop, snr, rssi, pkiStatus):
     try:
-        loc = []
-        msg = "You are " + str(message_from_id) + " AKA " +\
-                str(get_name_from_number(message_from_id, 'long', deviceID) + " AKA, " +\
-                str(get_name_from_number(message_from_id, 'short', deviceID)) + " AKA, " +\
-                str(decimal_to_hex(message_from_id)) + f"\n")
-        msg += f"I see the signal strength is {rssi} and the SNR is {snr} with hop count of {hop}"
-        if pkiStatus[1] != 'ABC':
-            msg += f"\nYour PKI bit is {pkiStatus[0]} pubKey: {pkiStatus[1]}"
-
-        loc = get_node_location(message_from_id, deviceID)
-        if loc != [my_settings.latitudeValue, my_settings.longitudeValue]:
-            msg += f"\nYou are at: lat:{loc[0]} lon:{loc[1]}"
-
-            # check the positionMetadata for nodeID and get metadata
-            if positionMetadata and message_from_id in positionMetadata:
-                metadata = positionMetadata[message_from_id]
-                msg += f" alt:{metadata.get('altitude')}, speed:{metadata.get('groundSpeed')} bit:{metadata.get('precisionBits')}"
+        name = get_name_from_number(message_from_id, 'long', deviceID)
+        msg = f"You are: {name}\nKey: {message_from_id}\nHops: {hop}"
+        if snr != 0 or rssi != 0:
+            msg += f"\nSNR:{snr} RSSI:{rssi}"
     except Exception as e:
         logger.error(f"System: Error in whoami: {e}")
         msg = "Error in whoami"
     return msg
 
-def handle_whois(message, deviceID, channel_number, message_from_id):
-    #return data on a node name or number
-    if  "?" in message:
-        return message.split("?")[0].title() + " command returns information on a node."
+def _haversine_km(lat1, lon1, lat2, lon2):
+    R = 6371
+    lat1, lon1, lat2, lon2 = map(math.radians, [lat1, lon1, lat2, lon2])
+    dlat, dlon = lat2 - lat1, lon2 - lon1
+    a = math.sin(dlat/2)**2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon/2)**2
+    return R * 2 * math.asin(math.sqrt(a))
+
+def _path_total_km(sender_prefix: str, path_nodes: list):
+    """Sum distance (km) across sender → repeaters → bot. Returns None if coords insufficient."""
+    waypoints = []
+
+    sender_loc = get_node_location(sender_prefix)
+    if sender_loc and (sender_loc[0] != 0.0 or sender_loc[1] != 0.0):
+        waypoints.append(sender_loc)
+
+    for node in path_nodes:
+        h = node[0]
+        match = next(
+            ((p, info) for p, info in _contacts.items()
+             if info.get('pubkey', '').startswith(h)),
+            None
+        )
+        if match:
+            lat = match[1].get('lat')
+            lon = match[1].get('lon')
+            if lat is not None and lon is not None and (lat != 0.0 or lon != 0.0):
+                waypoints.append([lat, lon])
+
+    bot_lat = my_settings.latitudeValue
+    bot_lon = my_settings.longitudeValue
+    if bot_lat or bot_lon:
+        waypoints.append([bot_lat, bot_lon])
+
+    if len(waypoints) < 2:
+        return None
+
+    total = sum(
+        _haversine_km(waypoints[i][0], waypoints[i][1],
+                      waypoints[i+1][0], waypoints[i+1][1])
+        for i in range(len(waypoints) - 1)
+    )
+    return round(total, 1)
+
+def handle_path(message_from_id, deviceID):
+    entry = _sender_paths.get(str(message_from_id))
+    if not entry:
+        return "No path info yet — send a message first"
+    hops = entry['hops']
+    nodes = entry['nodes']
+
+    if hops == 255 or hops == 0:
+        lines = ["0 hops (direct)"]
+    elif not nodes:
+        lines = [f"{hops} hops (node detail not available)"]
     else:
-        # get the nodeID from the message
-        msg = ''
-        node = ''
-        # find the requested node in db
-        if " " in message:
-            node = message.split(" ")[1]
-        if node.startswith("!") and len(node) == 9:
-            # mesh !hex
-            try:
-                node = int(node.strip("!"),16)
-            except ValueError as e:
-                node = 0
-        elif node.isalpha() or not node.isnumeric():
-            # try short name
-            node = get_num_from_short_name(node, deviceID)
+        lines = [f"{hops} hops"]
+        for node in nodes:
+            h, name = node[0], node[1]
+            node_prefix = node[2] if len(node) > 2 else None
+            display = (node_prefix or h)[:6].upper()
+            lines.append(f"{display}: {name}")
 
-        # get details on the node
-        for i in range(len(seenNodes)):
-            if seenNodes[i]['nodeID'] == int(node):
-                msg = f"Node: {seenNodes[i]['nodeID']} is {get_name_from_number(seenNodes[i]['nodeID'], 'long', deviceID)}\n"
-                msg += f"Last 👀: {time.ctime(seenNodes[i]['lastSeen'])} "
-                break
+    km = _path_total_km(str(message_from_id), nodes)
+    if km is not None:
+        lines.append(f"📏 {km} km traveled")
 
-        if msg == '':
-            msg = "Provide a valid node number or short name"
-        else:
-            # if the user is an admin show the channel and interface and location
-            if str(message_from_id) in bbs_admin_list:
-                location = get_node_location(seenNodes[i]['nodeID'], deviceID, channel_number)
-                msg += f"Ch: {seenNodes[i]['channel']}, Int: {seenNodes[i]['rxInterface']}"
-                msg += f"Lat: {location[0]}, Lon: {location[1]}\n"
-                if location != [my_settings.latitudeValue, my_settings.longitudeValue]:
-                    msg += f"Loc: {where_am_i(str(location[0]), str(location[1]))}"
-        return msg
+    return "\n".join(lines)
+
+
+def handle_whois(message, deviceID, channel_number, message_from_id):
+    if "?" in message:
+        return "whois <prefix> — look up a node by partial pubkey prefix or name"
+
+    term = message.split(" ", 1)[1].strip().lower() if " " in message else ""
+    if not term:
+        return "Usage: whois <prefix or name>"
+
+    matches = []
+    for prefix, info in _contacts.items():
+        if prefix.lower().startswith(term):
+            matches.append((prefix, info))
+
+    if not matches:
+        return f"No contact found matching '{term}'"
+
+    results = []
+    is_admin = str(message_from_id) in bbs_admin_list
+    for prefix, info in matches:
+        name_long = info.get('name_long', prefix)
+        name_short = info.get('name_short', prefix[:8])
+        last_seen = time.ctime(info['last_seen']) if info.get('last_seen') else "unknown"
+        snr = info.get('snr', 0)
+        msg = f"{name_long}\nKey: {prefix}\nSeen: {last_seen}"
+        if snr:
+            msg += f" SNR:{snr}"
+        if is_admin:
+            location = get_node_location(prefix, deviceID, channel_number)
+            if location != [my_settings.latitudeValue, my_settings.longitudeValue]:
+                msg += f"\nLat:{location[0]} Lon:{location[1]}"
+        results.append(msg)
+
+    return results[0] if len(results) == 1 else results
 
 def handle_boot(mesh=True):
     try:
@@ -1729,8 +1767,8 @@ def handle_boot(mesh=True):
             if my_settings.bbs_enabled:
                 logger.debug(f"System: BBS Enabled, {bbsdb} has {len(bbs_messages)} messages. Direct Mail Messages waiting: {(len(bbs_dm) - 1)}")
                 if my_settings.bbs_link_enabled:
-                    if len(bbs_link_whitelist) > 0:
-                        logger.debug(f"System: BBS Link Enabled with {len(bbs_link_whitelist)} peers")
+                    if my_settings.bbs_link_peers:
+                        logger.debug(f"System: BBS Link Enabled with {len(my_settings.bbs_link_peers)} peers: {my_settings.bbs_link_peers}")
                     else:
                         logger.debug(f"System: BBS Link Enabled allowing all")
             
@@ -1862,429 +1900,526 @@ def handle_boot(mesh=True):
     except Exception as e:
         logger.error(f"System: Error during boot: {e}")
 
-def onReceive(packet, interface):
+def _hop_string(path_len):
+    """Convert MeshCore path_len to a human-readable hop string."""
+    if path_len == 255:
+        return "Direct"
+    if path_len == 1:
+        return "1 Hop"
+    return f"{path_len} Hops"
+
+
+# Dedup cache: (pubkey_prefix, sender_timestamp) → time.time() when first seen
+_seen_dm_keys: dict = {}
+_SEEN_DM_TTL = 120  # seconds
+
+# Path cache: pubkey_prefix → {'hops': int, 'nodes': [(hash_hex, name), ...], 'ts': float}
+_sender_paths: dict = {}
+
+
+def _is_duplicate_dm(pubkey_prefix: str, sender_timestamp) -> bool:
+    """Return True if we already processed this exact DM (same sender + timestamp)."""
+    now = time.time()
+    # Prune old entries
+    expired = [k for k, t in _seen_dm_keys.items() if now - t > _SEEN_DM_TTL]
+    for k in expired:
+        del _seen_dm_keys[k]
+    key = (pubkey_prefix, sender_timestamp)
+    if key in _seen_dm_keys:
+        return True
+    _seen_dm_keys[key] = now
+    return False
+
+
+async def on_contact_msg(event):
+    """Handle incoming DMs via MeshCore CONTACT_MSG_RECV."""
     global seenNodes, msg_history, cmdHistory
-    # Priocess the incoming packet, handles the responses to the packet with auto_response()
-    # Sends the packet to the correct handler for processing
+    payload = event.payload  # dict: pubkey_prefix, text, SNR, path_len, sender_timestamp
+    message_from_id = str(payload.get('pubkey_prefix', ''))
+    if not message_from_id:
+        return
+    message_string = payload.get('text', '') or ''
+    message_log_string = message_string.replace('\r', ' ').replace('\n', ' ')
+    snr = float(payload.get('SNR', 0) or 0)
+    rssi = 0.0
+    path_len = payload.get('path_len', 255)
+    hop = _hop_string(path_len)
+    pkiStatus = (True, message_from_id)
+    isDM = True
+    channel_number = 0
+    rxNode = 1
 
-    if not isinstance(packet, dict):
-        logger.warning(f"System: Ignoring malformed packet type: {type(packet).__name__}")
+    if _is_duplicate_dm(message_from_id, payload.get('sender_timestamp')):
+        logger.debug(f"System: Duplicate DM from {message_from_id} ignored")
         return
 
-    decoded = packet.get('decoded')
-    if not isinstance(decoded, dict):
-        decoded = {}
-
-    # extract interface details from inbound packet
-    rxType = type(interface).__name__
-
-    # Values assinged to the packet
-    packet_id = None
-    rxNode = message_from_id = snr = rssi = hop = hop_away = channel_number = hop_start = hop_count = hop_limit = 0
-    pkiStatus = (False, 'ABC')
-    rxNodeHostName = None
-    replyIDset = None
-    emojiSeen = False
-    simulator_flag = False
-    isDM = False
-    channel_name = "unknown"
-    session_passkey = None
-    playingGame = False
-
-    if my_settings.DEBUGpacket:
-        # Debug print the interface object
-        for item in interface.__dict__.items(): intDebug = f"{item}\n"
-        logger.debug(f"System: Packet Received on {rxType} Interface\n {intDebug} \n END of interface \n")
-        # Debug print the packet for debugging
-        logger.debug(f"Packet Received\n {packet} \n END of packet \n")
-
-    # determine the rxNode based on the interface type
-    if rxType == 'TCPInterface':
-        rxHost = interface.__dict__.get('hostname', 'unknown')
-        rxNodeHostName = interface.__dict__.get('ip', None)
-        rxNode = next(
-            (i for i in range(1, 10)
-            if multiple_interface and rxHost and
-            globals().get(f'hostname{i}', '').split(':', 1)[0] in rxHost and
-            globals().get(f'interface{i}_type', '') == 'tcp'),None)
-
-    if rxType == 'SerialInterface':
-        rxInterface = interface.__dict__.get('devPath', 'unknown')
-        rxNode = next(
-            (i for i in range(1, 10)
-            if globals().get(f'port{i}', '') in rxInterface),None)
-
-    if rxType == 'BLEInterface':
-        rxNode = next(
-            (i for i in range(1, 10)
-            if globals().get(f'interface{i}_type', '') == 'ble'),0)
-        
-    if rxNode is None:
-        # default to interface 1 ## FIXME needs better like a default interface setting or hash lookup
-        if decoded.get('portnum') in ['ADMIN_APP', 'SIMULATOR_APP']:
-            session_passkey = decoded.get('admin', {}).get('sessionPasskey', None)
-        rxNode = 1
-
-    # check if the packet has a channel flag use it ## FIXME needs to be channel hash lookup
-    if packet.get('channel'):
-        channel_number = packet.get('channel')
-        channel_name = "unknown"
-        try:
-            res = resolve_channel_name(channel_number, rxNode, interface)
-            if res:
-                try:
-                    channel_name, _ = res
-                except Exception:
-                    channel_name = "unknown"
-            else:
-                # Search all interfaces for this channel
-                cache = build_channel_cache()
-                found_on_other = None
-                for device in cache:
-                    for chan_name, info in device.get("channels", {}).items():
-                        if str(info.get('number')) == str(channel_number) or str(info.get('hash')) == str(channel_number):
-                            found_on_other = device.get("interface_id")
-                            found_chan_name = chan_name
-                            break
-                    if found_on_other:
-                        break
-                if found_on_other and found_on_other != rxNode:
-                    logger.debug(
-                        f"System: Received Packet on Channel:{channel_number} ({found_chan_name}) on Interface:{rxNode}, but this channel is configured on Interface:{found_on_other}"
-                    )
-        except Exception as e:
-            logger.debug(f"System: channel resolution error: {e}")
-    
-        #debug channel info
-        # if "unknown" in str(channel_name):
-        #     logger.debug(f"System: Received Packet on Channel:{channel_number} on Interface:{rxNode}")
-        # else:
-        #     logger.debug(f"System: Received Packet on Channel:{channel_number} Name:{channel_name} on Interface:{rxNode}")
-
-    # check if the packet has a simulator flag
-    simulator_flag = decoded.get('simulator', False)
-    if isinstance(simulator_flag, dict):
-        # assume Software Simulator
-        simulator_flag = True
-
-    # set the message_from_id
-    message_from_id = packet.get('from')
-    if message_from_id is None:
-        logger.warning(f"System: Ignoring packet missing 'from' field on Device:{rxNode}")
-        return
-
-    # if message_from_id is not in the seenNodes list add it
-    if not any(node.get('nodeID') == message_from_id for node in seenNodes):
-        seenNodes.append({'nodeID': message_from_id, 'rxInterface': rxNode, 'channel': channel_number, 'welcome': False, 'first_seen': time.time(), 'lastSeen': time.time()})
-        if len(seenNodes) > MAX_SEEN_NODES:
-            seenNodes = seenNodes[-MAX_SEEN_NODES:]
-    else:
-        # update lastSeen time
-        for node in seenNodes:
-            if node.get('nodeID') == message_from_id:
-                node['lastSeen'] = time.time()
-                break
-    # BBS DM MAIL CHECKER
-    if bbs_enabled and decoded:
-        msg = bbs_check_dm(message_from_id)
-        if msg:
-            logger.info(f"System: BBS DM Delivery: {msg[1]} For: {get_name_from_number(message_from_id, 'long', rxNode)}")
-            message = "Mail: " + msg[1] + "  From: " + get_name_from_number(msg[2], 'long', rxNode)
-            bbs_delete_dm(msg[0], msg[1])
-            send_message(message, channel_number, message_from_id, rxNode)
-
-    # CHECK with ban_hammer() if the node is banned
-    if str(message_from_id) in my_settings.bbs_ban_list or str(message_from_id) in my_settings.autoBanlist:
-        logger.warning(f"System: Banned Node {message_from_id} tried to send a message. Ignored. Try adding to node firmware-blocklist")
-        return
-
-    # handle TEXT_MESSAGE_APP
     try:
-        if decoded.get('portnum') == 'TEXT_MESSAGE_APP':
-            message_bytes = decoded.get('payload', b'')
-            if isinstance(message_bytes, bytes):
-                message_string = message_bytes.decode('utf-8', errors='replace')
-            elif isinstance(message_bytes, str):
-                message_string = message_bytes
-            else:
-                logger.warning(f"System: Ignoring TEXT_MESSAGE_APP with invalid payload type: {type(message_bytes).__name__}")
-                return
-            message_log_string = message_string.replace('\r', ' ').replace('\n', ' ')
-            via_mqtt = decoded.get('viaMqtt', False)
-            transport_mechanism = (
-                packet.get('transport_mechanism')
-                or packet.get('transportMechanism')
-                or decoded.get('transport_mechanism')
-                or decoded.get('transportMechanism')
-                or 'unknown'
-            )
-            rx_time = decoded.get('rxTime', time.time())
-
-            # check if the packet is from us
-            if message_from_id in [myNodeNum1, myNodeNum2, myNodeNum3, myNodeNum4, myNodeNum5, myNodeNum6, myNodeNum7, myNodeNum8, myNodeNum9]:
-                logger.warning(f"System: Packet from self {message_from_id} loop or traffic replay detected")
-
-            # get the signal strength and snr if available
-            if packet.get('rxSnr') or packet.get('rxRssi'):
-                snr = packet.get('rxSnr', 0)
-                rssi = packet.get('rxRssi', 0)
-
-            # check if the packet has a publicKey flag use it
-            if packet.get('publicKey'):
-                pkiStatus = packet.get('pkiEncrypted', False), packet.get('publicKey', 'ABC')
-            
-            # Use packet id for threaded replies;
-            packet_id = packet.get('id', None)
-
-            # existing reply - unused for tracking
-            replyIDSet = packet.get('replyIDSet', None)
-            
-            # check if the packet has emoji flag set it // currently unused in the code
-            if packet.get('emoji'):
-                emojiSeen = packet.get('emoji', False)
-
-            # check if the packet has a hop count flag use it
-            if packet.get('hopsAway'):
-                hop_away = packet.get('hopsAway', 0)
-
-            if packet.get('hopStart'):
-                hop_start = packet.get('hopStart', 0)
-
-            if packet.get('hopLimit'):
-                hop_limit = packet.get('hopLimit', 0)
-            
-            # calculate hop count
-            hop = ""
-            if hop_limit > 0 and hop_start >= hop_limit:
-                hop_count = hop_away + (hop_start - hop_limit)
-            elif hop_limit > 0 and hop_start < hop_limit:
-                hop_count = hop_away + (hop_limit - hop_start)
-            else:
-                hop_count = hop_away
-
-            if hop_count > 0:
-                # set hop string from calculated hop count
-                hop = f"{hop_count} Hop" if hop_count == 1 else f"{hop_count} Hops"
-
-            if hop_start == hop_limit and "lora" in str(transport_mechanism).lower() and (snr != 0 or rssi != 0) and hop_count == 0:
-                # 2.7+ firmware direct hop over LoRa
-                hop = "Direct"
-
-            if via_mqtt or "mqtt" in str(transport_mechanism).lower():
-                hop = "MQTT"
-                via_mqtt = True
-            elif "udp" in str(transport_mechanism).lower():
-                hop = "Gateway"
-            
-            if hop in ("MQTT", "Gateway") and hop_count > 0:
-                hop = f" {hop_count} Hops"
-
-            # Add relay node info if present
-            if packet.get('relayNode') is not None:
-                relay_val = packet['relayNode']
-                last_byte = relay_val & 0xFF
-                if last_byte == 0x00:
-                    hex_val = 'OldFW'
-                else:
-                    hex_val = f"{last_byte:02X}"
-                hop += f" Relay:{hex_val}"
-
-            if enableHopLogs:
-                logger.debug(f"System: Packet HopDebugger: hop_away:{hop_away} hop_limit:{hop_limit} hop_start:{hop_start} calculated_hop_count:{hop_count} final_hop_value:{hop} via_mqtt:{via_mqtt} transport_mechanism:{transport_mechanism} Hostname:{rxNodeHostName}")
-
-            # check with stringSafeChecker if the message is safe
-            if stringSafeCheck(message_string, message_from_id) is False:
-                logger.warning(f"System: Possibly Unsafe Message from {get_name_from_number(message_from_id, 'long', rxNode)}")
-
-            if help_message in message_string or welcome_message in message_string or "CMD?:" in message_string:
-                # ignore help and welcome messages
-                logger.warning(f"Got Own Welcome/Help header. From: {get_name_from_number(message_from_id, 'long', rxNode)}")
-                return
-        
-            # If the packet is a DM (Direct Message) respond to it, otherwise validate its a message for us on the channel
-            if packet.get('to') in [myNodeNum1, myNodeNum2, myNodeNum3, myNodeNum4, myNodeNum5, myNodeNum6, myNodeNum7, myNodeNum8, myNodeNum9]:
-                # message is DM to us
-                isDM = True
-                # check if the message contains a trap word, DMs are always responded to
-                if (messageTrap(message_string) and not llm_enabled) or messageTrap(message_string.split()[0]):
-                    # log the message to stdout
-                    logger.info(f"Device:{rxNode} Channel: {channel_number} " + CustomFormatter.green + f"Received DM: " + CustomFormatter.white + f"{message_log_string} " + CustomFormatter.purple +\
-                                "From: " + CustomFormatter.white + f"{get_name_from_number(message_from_id, 'long', rxNode)}")
-                    # respond with DM
-                    send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM), channel_number, message_from_id, rxNode)
-                else:
-                    # DM is useful for games or LLM
-                    if games_enabled and ("Direct" in hop or hop_count < my_settings.game_hop_limit):
-                        playingGame = checkPlayingGame(message_from_id, message_string, rxNode, channel_number)
-                    elif hop_count >= my_settings.game_hop_limit:
-                        if games_enabled:
-                            logger.warning(f"Device:{rxNode} Ignoring Request to Play Game: {message_log_string} From: {get_name_from_number(message_from_id, 'long', rxNode)} with hop count: {hop}")
-                            send_message(f"Your hop count exceeds safe playable distance at {hop_count} hops", channel_number, message_from_id, rxNode)
-                        else:
-                            playingGame = False
-                    else:
-                        playingGame = False
-
-                    if not playingGame:
-                        if llm_enabled and my_settings.llmReplyToNonCommands:
-                            # respond with LLM
-                            llm = handle_llm(message_from_id, channel_number, rxNode, message_string, publicChannel)
-                            send_message(llm, channel_number, message_from_id, rxNode)
-                        else:
-                            # respond with welcome message on DM
-                            logger.warning(f"Device:{rxNode} Ignoring DM: {message_log_string} From: {get_name_from_number(message_from_id, 'long', rxNode)}")
-                            
-                            # if seenNodes list is not marked as welcomed send welcome message
-                            if not any(node['nodeID'] == message_from_id and node['welcome'] == True for node in seenNodes):
-                                # send welcome message
-                                send_message(welcome_message, channel_number, message_from_id, rxNode)
-                                # mark the node as welcomed
-                                for node in seenNodes:
-                                    if node['nodeID'] == message_from_id:
-                                        node['welcome'] = True
-                            else:
-                                if my_settings.dad_jokes_enabled:
-                                    # respond with a dad joke on DM
-                                    send_message(tell_joke(), channel_number, message_from_id, rxNode)
-                                else:
-                                    # respond with help message on DM
-                                    send_message(help_message, channel_number, message_from_id, rxNode)
-                    
-                    # add message to tts queue
-                    if meshagesTTS:
-                        # add to the tts_read_queue
-                        readMe = f"DM from {get_name_from_number(message_from_id, 'short', rxNode)}: {message_string}"
-                        tts_read_queue.append(readMe)
-                        
-                    # log the message to the message log
-                    if log_messages_to_file:
-                        msgLogger.info(f"Device:{rxNode} Channel:{channel_number} | {get_name_from_number(message_from_id, 'long', rxNode)} | DM | " + message_log_string)
-            else:
-                # message is on a channel
-                if messageTrap(message_string):
-                    # message is for us to respond to, or is it...
-                    if my_settings.ignoreDefaultChannel and channel_number == my_settings.publicChannel:
-                        logger.debug(f"System: Ignoring CMD:{message_log_string} From: {get_name_from_number(message_from_id, 'short', rxNode)} Default Channel:{channel_number}")
-                    elif str(message_from_id) in my_settings.bbs_ban_list:
-                        logger.debug(f"System: Ignoring CMD:{message_log_string} From: {get_name_from_number(message_from_id, 'short', rxNode)} Cantankerous Node")
-                    elif str(channel_number) in my_settings.ignoreChannels:
-                        logger.debug(f"System: Ignoring CMD:{message_log_string} From: {get_name_from_number(message_from_id, 'short', rxNode)} Ignored Channel:{channel_number}")
-                    elif my_settings.cmdBang and not message_string.startswith("!"):
-                        logger.debug(f"System: Ignoring CMD:{message_log_string} From: {get_name_from_number(message_from_id, 'short', rxNode)} Didnt sound like they meant it")
-                    else:
-                        # message is for bot to respond to, seriously this time..
-                        logger.info(f"Device:{rxNode} Channel:{channel_number} " + CustomFormatter.green + "ReceivedChannel: " + CustomFormatter.white + f"{message_log_string} " + CustomFormatter.purple +\
-                                    "From: " + CustomFormatter.white + f"{get_name_from_number(message_from_id, 'long', rxNode)}")
-                        if my_settings.useDMForResponse:
-                            # respond to channel message via direct message
-                            send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM), channel_number, message_from_id, rxNode, reply_id=packet_id)
-                        else:
-                            # or respond to channel message on the channel itself
-                            if channel_number == my_settings.publicChannel and my_settings.antiSpam:
-                                # warning user spamming default channel
-                                logger.warning(f"System: AntiSpam protection, sending DM to: {get_name_from_number(message_from_id, 'long', rxNode)}")
-                            
-                                # respond to channel message via direct message
-                                send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM), channel_number, message_from_id, rxNode, reply_id=packet_id)
-                            else:
-                                # respond to channel message on the channel itself
-                                send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM), channel_number, 0, rxNode, reply_id=packet_id)
-
-                else:
-                    # message is not for us to respond to
-                    # but if the sender is already playing a game, continue it.
-                    if games_enabled and checkPlayingGame(message_from_id, message_string, rxNode, channel_number):
-                        return
-
-                    # ignore the message but add it to the message history list
-                    if my_settings.zuluTime:
-                        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                    else:
-                        timestamp = datetime.now().strftime("%Y-%m-%d %I:%M:%S%p")
-
-                    # trim the history list if it exceeds max_history
-                    if len(msg_history) >= my_settings.MAX_MSG_HISTORY:
-                        # Always keep only the most recent MAX_MSG_HISTORY entries
-                        msg_history = msg_history[-my_settings.MAX_MSG_HISTORY:]
-
-                    # add the message to the history list
-                    msg_history.append((get_name_from_number(message_from_id, 'long', rxNode), message_string, channel_number, timestamp, rxNode))
-
-                    # print the message to the log and sdout
-                    logger.info(f"Device:{rxNode} Channel:{channel_number} " + CustomFormatter.green + "Ignoring Message:" + CustomFormatter.white +\
-                                f" {message_log_string} " + CustomFormatter.purple + "From:" + CustomFormatter.white + f" {get_name_from_number(message_from_id)}")
-                    if my_settings.log_messages_to_file:
-                        msgLogger.info(f"Device:{rxNode} Channel:{channel_number} | {get_name_from_number(message_from_id, 'long', rxNode)} | " + message_log_string)
-
-                    # repeat the message on the other device
-                    if my_settings.repeater_enabled and my_settings.multiple_interface:
-                        # wait a responseDelay to avoid message collision from lora-ack.
-                        time.sleep(my_settings.responseDelay)
-                        if len(message_string) > (3 * my_settings.MESSAGE_CHUNK_SIZE):
-                            logger.warning(f"System: Not repeating message, exceeds size limit ({len(message_string)} > {3 * MESSAGE_CHUNK_SIZE})")
-                        else:
-                            rMsg = (f"{message_string} From:{get_name_from_number(message_from_id, 'short', rxNode)}")
-                            # if channel found in the repeater list repeat the message
-                            if str(channel_number) in my_settings.repeater_channels:
-                                for i in range(1, 10):
-                                    if globals().get(f'interface{i}_enabled', False) and i != rxNode:
-                                        logger.debug(f"Repeating message on Device{i} Channel:{channel_number}")
-                                        send_message(rMsg, channel_number, 0, i)
-                                        time.sleep(my_settings.responseDelay)
-                    
-                    # if QRZ enabled check if we have said hello
-                    if my_settings.qrz_hello_enabled:
-                        if never_seen_before(message_from_id):
-                            name = get_name_from_number(message_from_id, 'short', rxNode)
-                            if isinstance(name, str) and name.startswith("!") and len(name) == 9:
-                                # we didnt get a info packet yet so wait and ingore this go around
-                                logger.debug(f"System: QRZ Hello ignored, no info packet yet")
-                            else:
-                                # add to qrz_hello list
-                                hello(message_from_id, name)
-                                # send a hello message as a DM
-                                if not my_settings.train_qrz:
-                                    send_message(f"Hello {name} {qrz_hello_string}", channel_number, message_from_id, rxNode, reply_id=packet_id)
-
-                    # handle mini games 
-                    if my_settings.wordOfTheDay:
-                        #word of the day game play on non bot messages
-                        happened, old_entry, new_entry, bingo_win, bingo_message = theWordOfTheDay.did_it_happen(message_string)
-                        if happened:
-                            wordWas = old_entry['word']
-                            metaWas = old_entry['meta']
-                            msg = f"🎉 {get_name_from_number(message_from_id, 'long', rxNode)} found the Word of the Day🎊:\n {wordWas}, {metaWas}"
-                            send_message(msg, channel_number, 0, rxNode)
-                        if bingo_win:
-                            msg = f"🎉 {get_name_from_number(message_from_id, 'long', rxNode)} scored word-search-BINGO!🥳 {bingo_message}"
-                            send_message(msg, channel_number, 0, rxNode)
-
-                        slotMachine = theWordOfTheDay.emojiMiniGame(message_string, emojiSeen=emojiSeen, nodeID=message_from_id, nodeInt=rxNode)
-                        if slotMachine:
-                            msg = f"🎉 {get_name_from_number(message_from_id, 'long', rxNode)} played the emote-Fruit-Machine and got: {slotMachine} 🥳"
-                            send_message(msg, channel_number, 0, rxNode)
-
-                    # add message to tts queue
-                    if my_settings.meshagesTTS and channel_number == my_settings.ttsChannels:
-                        # add to the tts_read_queue
-                        readMe = f"DM from {get_name_from_number(message_from_id, 'short', rxNode)}: {message_string}"
-                        tts_read_queue.append(readMe)
+        # Track sender
+        if not any(node.get('nodeID') == message_from_id for node in seenNodes):
+            seenNodes.append({'nodeID': message_from_id, 'rxInterface': rxNode, 'channel': channel_number,
+                              'welcome': False, 'first_seen': time.time(), 'lastSeen': time.time()})
+            if len(seenNodes) > MAX_SEEN_NODES:
+                seenNodes = seenNodes[-MAX_SEEN_NODES:]
         else:
-            # Evaluate non TEXT_MESSAGE_APP packets
-            consumeMetadata(packet, rxNode, channel_number)
+            for node in seenNodes:
+                if node.get('nodeID') == message_from_id:
+                    node['lastSeen'] = time.time()
+                    break
+
+        update_contact(message_from_id, snr=snr)
+        update_leaderboard_from_rx(message_from_id)  # rssi not available from CONTACT_MSG_RECV
+
+        # Record path info (hop count only — node list available from raw path)
+        if message_from_id not in _sender_paths or not _sender_paths[message_from_id].get('nodes'):
+            _sender_paths[message_from_id] = {'hops': path_len, 'nodes': [], 'ts': time.time()}
+
+        # BBS pending DM mail delivery
+        if bbs_enabled:
+            msg = bbs_check_dm(message_from_id)
+            if msg:
+                logger.info(f"System: BBS DM Delivery: {msg[1]} For: {get_name_from_number(message_from_id, 'long', rxNode)}")
+                mail_text = "Mail: " + msg[1] + "  From: " + get_name_from_number(msg[2], 'long', rxNode)
+                bbs_delete_dm(msg[0], msg[1])
+                await send_message(mail_text, channel_number, message_from_id, rxNode)
+
+        # Ban check
+        if str(message_from_id) in my_settings.bbs_ban_list or str(message_from_id) in my_settings.autoBanlist:
+            logger.warning(f"System: Banned Node {message_from_id} tried to send a message. Ignored.")
+            return
+
+        if not stringSafeCheck(message_string, message_from_id):
+            logger.warning(f"System: Possibly Unsafe Message from {get_name_from_number(message_from_id, 'long', rxNode)}")
+            return
+
+        if help_message in message_string or welcome_message in message_string or "CMD?:" in message_string:
+            logger.warning(f"Got Own Welcome/Help header. From: {get_name_from_number(message_from_id, 'long', rxNode)}")
+            return
+
+        # Early async intercept for bbslink/bbsack — must be awaited due to async sleeps
+        if bbs_enabled and my_settings.bbs_link_enabled:
+            _msg_lower = message_string.lower()
+            if 'bbslink' in _msg_lower or 'bbsack' in _msg_lower:
+                response = await bbs_sync_posts(message_string, message_from_id, rxNode)
+                if response:
+                    await send_message(response, channel_number, message_from_id, rxNode)
+                return
+
+        if (messageTrap(message_string) and not llm_enabled) or (message_string.split() and messageTrap(message_string.split()[0])):
+            logger.info(f"Device:{rxNode} " + CustomFormatter.green + "Received DM: " + CustomFormatter.white +
+                        f"{message_log_string} " + CustomFormatter.purple + "From: " + CustomFormatter.white +
+                        f"({message_from_id}) {get_name_from_number(message_from_id, 'long', rxNode)}")
+            _resp = auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM)
+            if isinstance(_resp, list):
+                for _part in _resp:
+                    await send_message(_part, channel_number, message_from_id, rxNode)
+            else:
+                await send_message(_resp, channel_number, message_from_id, rxNode)
+        else:
+            # Not a command — check for active game, LLM, or welcome
+            playingGame = False
+            if games_enabled and (path_len == 255 or path_len < my_settings.game_hop_limit):
+                playingGame = checkPlayingGame(message_from_id, message_string, rxNode, channel_number)
+            elif games_enabled and path_len >= my_settings.game_hop_limit:
+                logger.warning(f"Device:{rxNode} Ignoring game request from {get_name_from_number(message_from_id, 'long', rxNode)}: hop count too high")
+                await send_message(f"Your hop count exceeds safe playable distance at {hop}", channel_number, message_from_id, rxNode)
+
+            if not playingGame:
+                if llm_enabled and my_settings.llmReplyToNonCommands:
+                    llm = handle_llm(message_from_id, channel_number, rxNode, message_string, publicChannel)
+                    await send_message(llm, channel_number, message_from_id, rxNode)
+                else:
+                    logger.warning(f"Device:{rxNode} Ignoring DM: {message_log_string} From: {get_name_from_number(message_from_id, 'long', rxNode)}")
+                    if not any(node['nodeID'] == message_from_id and node['welcome'] for node in seenNodes):
+                        await send_message(welcome_message, channel_number, message_from_id, rxNode)
+                        for node in seenNodes:
+                            if node['nodeID'] == message_from_id:
+                                node['welcome'] = True
+                    else:
+                        if my_settings.dad_jokes_enabled:
+                            await send_message(tell_joke(), channel_number, message_from_id, rxNode)
+                        else:
+                            await send_message(help_message, channel_number, message_from_id, rxNode)
+
+            if meshagesTTS:
+                tts_read_queue.append(f"DM from {get_name_from_number(message_from_id, 'short', rxNode)}: {message_string}")
+
+        if log_messages_to_file:
+            msgLogger.info(f"Device:{rxNode} Channel:{channel_number} | {get_name_from_number(message_from_id, 'long', rxNode)} | DM | " + message_log_string)
+
     except Exception as e:
-        logger.exception(f"System: Error processing packet: {e} Device:{rxNode}")
-        logger.debug(f"System: Error Packet = {packet}")
+        logger.exception(f"System: Error processing DM from {message_from_id}: {e}")
+
+
+async def on_channel_msg(event):
+    """Handle incoming channel messages via MeshCore CHANNEL_MSG_RECV."""
+    global seenNodes, msg_history
+    payload = event.payload  # dict: channel_idx, text, pubkey_prefix, SNR, RSSI, path_len
+    message_from_id = str(payload.get('pubkey_prefix', ''))
+    message_string = payload.get('text', '') or ''
+    message_log_string = message_string.replace('\r', ' ').replace('\n', ' ')
+    channel_number = int(payload.get('channel_idx', 0))
+    snr = float(payload.get('SNR', 0) or 0)
+    rssi = float(payload.get('RSSI', 0) or 0)
+    path_len = payload.get('path_len', 0)
+    hop = _hop_string(path_len)
+    pkiStatus = (False, message_from_id)
+    isDM = False
+    rxNode = 1
+
+    try:
+        if message_from_id:
+            update_contact(message_from_id, snr=snr)
+            if not any(node.get('nodeID') == message_from_id for node in seenNodes):
+                seenNodes.append({'nodeID': message_from_id, 'rxInterface': rxNode, 'channel': channel_number,
+                                  'welcome': False, 'first_seen': time.time(), 'lastSeen': time.time()})
+            else:
+                for node in seenNodes:
+                    if node.get('nodeID') == message_from_id:
+                        node['lastSeen'] = time.time()
+                        break
+
+            # BBS pending DM mail delivery on any received packet
+            if bbs_enabled:
+                msg = bbs_check_dm(message_from_id)
+                if msg:
+                    logger.info(f"System: BBS DM Delivery: {msg[1]} For: {get_name_from_number(message_from_id, 'long', rxNode)}")
+                    mail_text = "Mail: " + msg[1] + "  From: " + get_name_from_number(msg[2], 'long', rxNode)
+                    bbs_delete_dm(msg[0], msg[1])
+                    await send_message(mail_text, 0, message_from_id, rxNode)
+
+            if str(message_from_id) in my_settings.bbs_ban_list or str(message_from_id) in my_settings.autoBanlist:
+                return
+
+        if not stringSafeCheck(message_string, message_from_id):
+            return
+
+        if help_message in message_string or welcome_message in message_string or "CMD?:" in message_string:
+            return
+
+        # Early async intercept for bbslink/bbsack — respond via DM to avoid channel spam
+        if bbs_enabled and my_settings.bbs_link_enabled:
+            _msg_lower = message_string.lower()
+            if 'bbslink' in _msg_lower or 'bbsack' in _msg_lower:
+                response = await bbs_sync_posts(message_string, message_from_id, rxNode)
+                if response:
+                    await send_message(response, 0, message_from_id, rxNode)
+                return
+
+        if messageTrap(message_string):
+            if my_settings.ignoreDefaultChannel and channel_number == my_settings.publicChannel:
+                logger.debug(f"System: Ignoring CMD:{message_log_string} From: {get_name_from_number(message_from_id, 'short', rxNode)} Default Channel:{channel_number}")
+            elif str(message_from_id) in my_settings.bbs_ban_list:
+                logger.debug(f"System: Ignoring CMD from banned node: {get_name_from_number(message_from_id, 'short', rxNode)}")
+            elif str(channel_number) in my_settings.ignoreChannels:
+                logger.debug(f"System: Ignoring CMD on ignored channel {channel_number}")
+            elif my_settings.cmdBang and not message_string.startswith("!"):
+                logger.debug(f"System: Ignoring CMD (cmdBang): {message_log_string}")
+            else:
+                logger.info(f"Device:{rxNode} Channel:{channel_number} " + CustomFormatter.green + "ReceivedChannel: " +
+                            CustomFormatter.white + f"{message_log_string} " + CustomFormatter.purple + "From: " +
+                            CustomFormatter.white + f"({message_from_id}) {get_name_from_number(message_from_id, 'long', rxNode)}")
+                response = auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM)
+                _responses = response if isinstance(response, list) else [response]
+                for _r in _responses:
+                    if my_settings.useDMForResponse:
+                        await send_message(_r, channel_number, message_from_id, rxNode)
+                    elif channel_number == my_settings.publicChannel and my_settings.antiSpam:
+                        logger.warning(f"System: AntiSpam protection, sending DM to: {get_name_from_number(message_from_id, 'long', rxNode)}")
+                        await send_message(_r, channel_number, message_from_id, rxNode)
+                    else:
+                        await send_message(_r, channel_number, 0, rxNode)
+        else:
+            # Non-command channel message
+            if games_enabled and message_from_id and checkPlayingGame(message_from_id, message_string, rxNode, channel_number):
+                return
+
+            if my_settings.zuluTime:
+                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            else:
+                timestamp = datetime.now().strftime("%Y-%m-%d %I:%M:%S%p")
+
+            if len(msg_history) >= my_settings.MAX_MSG_HISTORY:
+                msg_history = msg_history[-my_settings.MAX_MSG_HISTORY:]
+            msg_history.append((get_name_from_number(message_from_id, 'long', rxNode), message_string, channel_number, timestamp, rxNode))
+
+            logger.info(f"Device:{rxNode} Channel:{channel_number} " + CustomFormatter.green + "Ignoring Message:" +
+                        CustomFormatter.white + f" {message_log_string} " + CustomFormatter.purple + "From:" +
+                        CustomFormatter.white + f" {get_name_from_number(message_from_id)}")
+            if my_settings.log_messages_to_file:
+                msgLogger.info(f"Device:{rxNode} Channel:{channel_number} | {get_name_from_number(message_from_id, 'long', rxNode)} | " + message_log_string)
+
+            # Repeater mode
+            if my_settings.repeater_enabled and my_settings.multiple_interface:
+                if len(message_string) <= (3 * my_settings.MESSAGE_CHUNK_SIZE):
+                    rMsg = f"{message_string} From:{get_name_from_number(message_from_id, 'short', rxNode)}"
+                    if str(channel_number) in my_settings.repeater_channels:
+                        for i in range(1, 10):
+                            if globals().get(f'interface{i}_enabled', False) and i != rxNode:
+                                logger.debug(f"Repeating message on Device{i} Channel:{channel_number}")
+                                await send_message(rMsg, channel_number, 0, i)
+
+            # QRZ hello for new nodes on channel
+            if my_settings.qrz_hello_enabled and message_from_id:
+                if never_seen_before(message_from_id):
+                    name = get_name_from_number(message_from_id, 'short', rxNode)
+                    if not (isinstance(name, str) and name.startswith("!") and len(name) == 9):
+                        hello(message_from_id, name)
+                        if not my_settings.train_qrz:
+                            await send_message(f"Hello {name} {qrz_hello_string}", channel_number, message_from_id, rxNode)
+
+            # Word of the day mini-games
+            if my_settings.wordOfTheDay and message_from_id:
+                happened, old_entry, new_entry, bingo_win, bingo_message = theWordOfTheDay.did_it_happen(message_string)
+                if happened:
+                    wordWas = old_entry['word']
+                    metaWas = old_entry['meta']
+                    msg = f"🎉 {get_name_from_number(message_from_id, 'long', rxNode)} found the Word of the Day🎊:\n {wordWas}, {metaWas}"
+                    await send_message(msg, channel_number, 0, rxNode)
+                if bingo_win:
+                    msg = f"🎉 {get_name_from_number(message_from_id, 'long', rxNode)} scored word-search-BINGO!🥳 {bingo_message}"
+                    await send_message(msg, channel_number, 0, rxNode)
+                slotMachine = theWordOfTheDay.emojiMiniGame(message_string, emojiSeen=False, nodeID=message_from_id, nodeInt=rxNode)
+                if slotMachine:
+                    msg = f"🎉 {get_name_from_number(message_from_id, 'long', rxNode)} played the emote-Fruit-Machine and got: {slotMachine} 🥳"
+                    await send_message(msg, channel_number, 0, rxNode)
+
+            if my_settings.meshagesTTS and channel_number == my_settings.ttsChannels and message_from_id:
+                tts_read_queue.append(f"DM from {get_name_from_number(message_from_id, 'short', rxNode)}: {message_string}")
+
+    except Exception as e:
+        logger.exception(f"System: Error processing channel message on ch{channel_number}: {e}")
+
+def _ingest_contact(c: dict):
+    """Store a contact from a MeshCore CONTACTS or NEW_CONTACT event into the cache."""
+    pubkey = c.get('public_key', '')
+    if not pubkey:
+        return
+    prefix = pubkey[:12]
+    name = c.get('adv_name', '').strip('\x00').strip() or prefix
+    short = name[:8] if len(name) > 8 else name
+    lat = c.get('adv_lat')
+    lon = c.get('adv_lon')
+    update_contact(prefix, name_long=name, name_short=short, pubkey=pubkey, lat=lat, lon=lon)
+    logger.debug(f"System: Contact cached: {prefix} → {name}")
+
+
+async def on_contacts(event):
+    """Bulk-load contacts after get_contacts() completes."""
+    contacts = event.payload  # dict: {public_key: contact_dict}
+    if isinstance(contacts, dict):
+        for c in contacts.values():
+            _ingest_contact(c)
+        logger.debug(f"System: Loaded {len(contacts)} contact(s) from radio")
+
+
+async def on_new_contact(event):
+    """Handle a newly advertised contact."""
+    _ingest_contact(event.payload)
+
+
+_ROUTE_TYPES = {0: "FLOOD", 1: "FLOOD", 2: "DIRECT", 3: "T-DIRECT"}
+_PKT_TYPES   = {0: "REQUEST", 1: "RESPONSE", 2: "DM", 3: "ACK",
+                4: "ADVERT", 5: "CHAN", 6: "CHAN-DATA", 7: "ANON",
+                8: "PATH", 9: "TRACE", 10: "MULTI", 11: "CTRL", 15: "RAW"}
+
+
+async def _process_raw_dm(raw: bytes, hops: int, snr, rssi, device_id: int):
+    """Decrypt a TEXT_MESSAGE packet from RX_LOG_DATA and dispatch it as a DM."""
+    import hmac as _hmac, hashlib as _hashlib
+    import nacl.bindings as _nacl
+    from Crypto.Cipher import AES
+
+    private_key, public_key = get_bot_keys()
+    if not private_key or not public_key:
+        return
+
+    # Parse path to find payload offset
+    if len(raw) < 2:
+        return
+    path_byte = raw[1]
+    hash_mode = (path_byte >> 6) & 0x03
+    hash_size = hash_mode + 1
+    hop_count = path_byte & 0x3F
+    payload_offset = 2 + hop_count * hash_size
+
+    if len(raw) < payload_offset + 4:
+        return
+    payload = raw[payload_offset:]
+
+    dest_hash = format(payload[0], "02x").lower()
+    src_hash  = format(payload[1], "02x").lower()
+    our_first = format(public_key[0], "02x").lower()
+
+    if dest_hash != our_first:
+        return  # Not addressed to us
+
+    # Find candidate senders: contact whose pubkey starts with src_hash byte
+    candidates = [(pfx, info) for pfx, info in _contacts.items()
+                  if info.get('pubkey', '').startswith(src_hash)]
+    if not candidates:
+        logger.debug(f"System: RX DM (raw) - no contact for src_hash={src_hash}")
+        return
+
+    mac_bytes  = payload[2:4]
+    ciphertext = payload[4:]
+    if not ciphertext or len(ciphertext) % 16 != 0:
+        return
+
+    # Clamp private key scalar (X25519 requirement; idempotent for MeshCore keys)
+    clamped = bytearray(private_key[:32])
+    clamped[0] &= 248; clamped[31] &= 63; clamped[31] |= 64
+    clamped = bytes(clamped)
+
+    for prefix, info in candidates:
+        pubkey_hex = info.get('pubkey', '')
+        if len(pubkey_hex) != 64:
+            continue
+        try:
+            their_pub = bytes.fromhex(pubkey_hex)
+            x25519    = _nacl.crypto_sign_ed25519_pk_to_curve25519(their_pub)
+            secret    = _nacl.crypto_scalarmult(clamped, x25519)
+
+            calc_mac = _hmac.new(secret, ciphertext, _hashlib.sha256).digest()[:2]
+            if calc_mac != mac_bytes:
+                continue  # Wrong contact, try next
+
+            decrypted = AES.new(secret[:16], AES.MODE_ECB).decrypt(ciphertext)
+            if len(decrypted) < 5:
+                continue
+
+            sender_ts = int.from_bytes(decrypted[0:4], "little")
+            msg_bytes = decrypted[5:]
+            null_idx  = msg_bytes.find(b'\x00')
+            if null_idx >= 0:
+                msg_bytes = msg_bytes[:null_idx]
+            message_text = msg_bytes.decode('utf-8', errors='replace').strip()
+            if not message_text:
+                continue
+
+            if _is_duplicate_dm(prefix, sender_ts):
+                logger.debug(f"System: RX DM (raw) dedup skip from {prefix}")
+                return
+
+            # Parse path nodes for the `path` command
+            path_data = raw[2:2 + hop_count * hash_size]
+            path_nodes = []
+            for j in range(hop_count):
+                h = path_data[j*hash_size:(j+1)*hash_size].hex()
+                match = next(((p, i2) for p, i2 in _contacts.items()
+                              if i2.get('pubkey', '').startswith(h)), None)
+                node_name   = match[1].get('name_long', match[0]) if match else h
+                node_prefix = match[0] if match else None
+                path_nodes.append((h, node_name, node_prefix))
+            _sender_paths[prefix] = {'hops': hop_count, 'nodes': path_nodes, 'ts': time.time()}
+            update_leaderboard_from_rx(prefix, rssi)
+
+            # Refresh contact cache so send_msg_with_retry gets the current out_path_len
+            # from the radio (it learns the repeater return path upon receiving this packet)
+            if hop_count > 0:
+                _iface = get_interface(device_id)
+                if _iface:
+                    try:
+                        await _iface.commands.get_contacts()
+                    except Exception:
+                        pass
+
+            hop_str = _hop_string(hops)
+            name = info.get('name_long', prefix)
+            path_label = "direct" if hop_count == 0 else f"{hop_count}-hop repeater"
+            logger.info(f"Device:{device_id} RX DM ({path_label}) from ({prefix}) {name}: {message_text[:60]}")
+
+            # BBS pending DM delivery
+            if bbs_enabled:
+                bbs_msg = bbs_check_dm(prefix)
+                if bbs_msg:
+                    logger.info(f"System: BBS DM Delivery to {name}: {bbs_msg[1]}")
+                    mail_text = "Mail: " + bbs_msg[1] + "  From: " + get_name_from_number(bbs_msg[2], 'long', device_id)
+                    bbs_delete_dm(bbs_msg[0], bbs_msg[1])
+                    await send_message(mail_text, 0, prefix, device_id)
+
+            if (messageTrap(message_text) and not llm_enabled) or (message_text.split() and messageTrap(message_text.split()[0])):
+                response = auto_response(message_text, snr, rssi, hop_str, False,
+                                         prefix, 0, device_id, True)
+                if isinstance(response, list):
+                    for part in response:
+                        await send_message(part, 0, prefix, device_id)
+                else:
+                    await send_message(response, 0, prefix, device_id)
+            else:
+                # Non-command: check for active game first
+                played = False
+                if games_enabled and hops < my_settings.game_hop_limit:
+                    played = checkPlayingGame(prefix, message_text, device_id, 0)
+                if not played:
+                    if llm_enabled and my_settings.llmReplyToNonCommands:
+                        await send_message(handle_llm(prefix, 0, device_id, message_text, 0), 0, prefix, device_id)
+                    else:
+                        await send_message(welcome_message, 0, prefix, device_id)
+            return
+        except Exception as e:
+            logger.debug(f"System: DM decrypt failed for {prefix}: {e}")
+            continue
+
+
+def _make_rx_handler(device_id: int):
+    async def handler(event):
+        payload = event.payload or {}
+        raw_hex = payload.get("payload", "")
+        snr  = payload.get("snr", 0)
+        rssi = payload.get("rssi", 0)
+        if not raw_hex:
+            logger.debug("System: RX_LOG_DATA (empty payload)")
+            return
+        try:
+            raw = bytes.fromhex(raw_hex)
+            header   = raw[0]
+            route    = _ROUTE_TYPES.get(header & 0x03, f"R{header & 0x03}")
+            pkt_id   = (header >> 2) & 0x0F
+            pkt_type = _PKT_TYPES.get(pkt_id, f"T{pkt_id}")
+            hops     = (raw[1] & 0x3F) if len(raw) > 1 else 0
+            logger.debug(f"System: RX {pkt_type} via {route} hops:{hops} SNR:{snr} RSSI:{rssi} len:{len(raw)}")
+            if pkt_id == 0x02:  # TEXT_MESSAGE — try to decrypt as DM
+                await _process_raw_dm(raw, hops, snr, rssi, device_id)
+        except Exception:
+            logger.debug(f"System: RX_LOG_DATA (parse error) hex={raw_hex[:16]}")
+    return handler
+
 
 async def start_rx():
-    # Start the receive subscriber using pubsub via meshtastic library
-    pub.subscribe(onReceive, 'meshtastic.receive')
-    pub.subscribe(onDisconnect, 'meshtastic.connection.lost')
+    """Subscribe to MeshCore events on all connected interfaces, then drain buffered messages."""
+    from meshcore import EventType as ET
+    import modules.system as _sys
+    for i in range(1, 10):
+        mc = _sys.get_interface(i)
+        if mc:
+            mc.subscribe(EventType.CONTACT_MSG_RECV, on_contact_msg)
+            mc.subscribe(EventType.CHANNEL_MSG_RECV, on_channel_msg)
+            mc.subscribe(EventType.CONTACTS, on_contacts)
+            mc.subscribe(EventType.NEW_CONTACT, on_new_contact)
+            mc.subscribe(EventType.MESSAGES_WAITING, lambda e: logger.debug("System: MESSAGES_WAITING received"))
+            mc.subscribe(EventType.RX_LOG_DATA, _make_rx_handler(i))
+            logger.debug(f"System: Subscribed to events on Interface{i}")
+            # Refresh contacts so names are populated before handling any messages
+            try:
+                await mc.commands.get_contacts()
+            except Exception:
+                pass
+            # Drain messages buffered on the radio while we were offline
+            drained = 0
+            while True:
+                try:
+                    result = await mc.commands.get_msg(timeout=2.0)
+                except Exception:
+                    break
+                if result.type in (ET.NO_MORE_MSGS, ET.ERROR):
+                    break
+                drained += 1
+                await asyncio.sleep(0.05)
+            if drained:
+                logger.info(f"System: Interface{i} drained {drained} buffered message(s)")
     logger.debug("System: RX Subscriber started")
-    # here we go loopty loo
     while True:
         await asyncio.sleep(0.5)
-        pass
 
 # Initialize game trackers
 loadLeaderboard()
@@ -2308,6 +2443,7 @@ async def main():
     tasks = []
     
     try:
+        await init_interfaces()  # Connect to MeshCore radio(s) before anything else
         handle_boot()
         # Create core tasks
         tasks.append(asyncio.create_task(start_rx(), name="mesh_rx"))

--- a/migration.md
+++ b/migration.md
@@ -1,0 +1,631 @@
+# MeshCore Migration Plan
+
+Migration of `meshing-around-mc` from the Meshtastic Python library to MeshCore (`meshcore` / meshcore_py).
+
+**Source of truth for MeshCore patterns**: `../Remote-Terminal-for-MeshCore/`  
+**Goal**: Keep every feature intact. Only the radio backend changes.  
+**Scope**: Single radio (Serial, TCP, or BLE). DM-only response mode.
+
+---
+
+## Conceptual Differences to Internalize
+
+| Concept | Meshtastic | MeshCore |
+|---|---|---|
+| Node identity | 32-bit integer (`2813308004`) | 64-char hex public key (`aabbcc...`) |
+| Short identity | `!aabbccdd` (hex of int) | 12-char key prefix |
+| Node name | `longName` / `shortName` from `interface.nodes` | `name` from contact sync |
+| Event model | PyPubSub `pub.subscribe('meshtastic.receive', cb)` | `mc.subscribe(EventType.X, async_handler)` |
+| Sending DM | `interface.sendText(text, destinationId=int_id)` | `await mc.commands.send_msg(pubkey_hex, text)` |
+| Sending channel | `interface.sendText(text, channelIndex=ch)` | `await mc.commands.send_chan_msg(slot_idx, text)` |
+| SNR / RSSI | `packet['rxSnr']`, `packet['rxRssi']` | Decoded from `RX_LOG_DATA` raw bytes |
+| Hop count | Computed from `hopStart`, `hopLimit`, `hopsAway` | `path_len` from `RX_LOG_DATA` decoded path |
+| GPS location | `interface.nodes[id]['position']` | `contact.lat`, `contact.lon` (from advert) |
+| Channel list | `interface.getNode('^local').get_channels_with_hash()` | Managed via `mc.commands.set_channel()` |
+| Connection | Sync, blocking | Async, `await MeshCore.create_*()` |
+
+**Critical implication**: `message_from_id` changes from `int` to `str` (public key prefix). This propagates into every command handler, all game trackers, ban/admin lists, BBS, and `seenNodes`. The plan handles this explicitly in Phase 3.
+
+---
+
+## Phases
+
+### Phase 0 — Dependencies & Config
+
+**Files**: `requirements.txt`, `config.template`, `modules/settings.py`
+
+- [ ] Remove `meshtastic` and `PyPubSub` from `requirements.txt`
+- [ ] Add `meshcore` (meshcore_py) to `requirements.txt`
+- [ ] Add `pycryptodome` (needed for DM decryption, already used by Remote-Terminal)
+- [ ] In `config.template`, replace `[interface]` Meshtastic settings with MeshCore equivalents:
+  ```ini
+  [interface]
+  # type: serial | tcp | ble
+  type = serial
+  port = /dev/ttyACM0
+  # tcp: hostname = 192.168.1.1
+  # tcp: port = 5000
+  # ble: mac = AA:BB:CC:DD:EE:FF
+  # ble: pin = 1234
+  ```
+- [ ] In `modules/settings.py`, update any Meshtastic-specific defaults (e.g., `publicChannel`, `wantAck`, port names)
+- [ ] Verify no other module imports from `meshtastic` directly (grep: `import meshtastic`)
+
+---
+
+### Phase 1 — Radio Layer (`modules/system.py`)
+
+This file owns all Meshtastic interface calls. Replace top-to-bottom.
+
+#### 1a. Imports and connection
+
+**Remove**:
+```python
+import meshtastic.serial_interface
+import meshtastic.tcp_interface
+import meshtastic.ble_interface
+from pubsub import pub
+```
+
+**Add**:
+```python
+import asyncio
+from meshcore import MeshCore, EventType
+```
+
+**Remove** the entire interface init loop (lines ~334–371 in system.py) that creates `interface1`–`interface9`.
+
+**Add** a single async connect helper:
+```python
+_mc = None  # global MeshCore connection handle
+
+async def connect_radio():
+    global _mc
+    if interface1_type == 'serial':
+        _mc = await MeshCore.create_serial(port=port1 or None)
+    elif interface1_type == 'tcp':
+        host = hostname1.split(':')[0] if ':' in str(hostname1) else hostname1
+        tcp_port = int(hostname1.split(':')[1]) if ':' in str(hostname1) else 5000
+        _mc = await MeshCore.create_tcp(host=host, port=tcp_port)
+    elif interface1_type == 'ble':
+        _mc = await MeshCore.create_ble(address=mac1, pin=str(ble_pin1))
+    return _mc
+```
+
+Reference: `../Remote-Terminal-for-MeshCore/app/radio.py` — `RadioManager._connect()`
+
+#### 1b. `get_my_node_info()`
+
+**Remove**: `interface.getMyNodeInfo()['num']`
+
+**Add**: Get the bot's own public key after connect:
+```python
+_my_public_key = None  # set after connect
+
+async def fetch_own_identity():
+    global _my_public_key
+    info = await _mc.commands.get_device_info()
+    _my_public_key = info.get('public_key', '')
+```
+
+Reference: `../Remote-Terminal-for-MeshCore/app/services/radio_commands.py`
+
+#### 1c. `send_message()`
+
+**Current signature**: `send_message(message, ch, nodeid=0, nodeInt=1, bypassChuncking=False, reply_id=None)`
+
+- `nodeid=0` means channel send; `nodeid != 0` means DM.
+- `ch` is the channel slot index.
+
+**Replace** `interface.sendText()` / `interface.sendData()`:
+```python
+async def send_message(message, ch, nodeid=None, nodeInt=1, bypassChuncking=False, reply_id=None):
+    if not _mc:
+        logger.error("send_message: radio not connected")
+        return False
+    chunks = messageChunker(message) if not bypassChuncking else [message]
+    if isinstance(chunks, str):
+        chunks = [chunks]
+    for chunk in chunks:
+        try:
+            if nodeid:
+                await _mc.commands.send_msg(nodeid, chunk)   # DM by pubkey
+            else:
+                await _mc.commands.send_chan_msg(ch, chunk)  # channel by slot index
+            await asyncio.sleep(splitDelay)
+        except Exception as e:
+            logger.error(f"send_message error: {e}")
+            return False
+    return True
+```
+
+> **Note**: `reply_id` threading is Meshtastic-specific. MeshCore has no equivalent. Drop it silently for now.
+
+All callers of `send_message()` in `mesh_bot.py` must be updated to `await send_message(...)`. Because `auto_response()` returns a string and its callers send it, the callers become async (see Phase 2).
+
+#### 1d. `send_raw_bytes()`
+
+MeshCore has no raw portnum-based data send equivalent for bot use. This is only used by the `echo` binary mode (which is gated behind `echoBinary = False`) and by `modules/udp.py`. Mark as not-implemented stub:
+```python
+async def send_raw_bytes(nodeid, raw_bytes, nodeInt=1, channel=0, portnum=256, want_ack=True, reply_id=None):
+    logger.warning("send_raw_bytes: not supported on MeshCore, skipping")
+    return False
+```
+
+#### 1e. Contact / node lookup
+
+**Remove**: All uses of `interface.nodes`.
+
+**Add**: In-memory contact cache built from MeshCore events:
+```python
+_contacts: dict[str, dict] = {}
+# key = full pubkey hex (64 chars)
+# value = {'name': str, 'lat': float, 'lon': float, 'last_seen': float}
+```
+
+**Replace** `get_name_from_number(number, type, nodeInt)`:
+```python
+def get_name_from_number(pubkey, type='long', nodeInt=1):
+    # pubkey is now a hex string (full or 12-char prefix)
+    contact = _get_contact(pubkey)
+    if contact:
+        return contact.get('name', pubkey[:12])
+    return pubkey[:12] if pubkey else '?'
+```
+
+**Replace** `get_num_from_short_name(short_name, nodeInt)`:
+```python
+def get_num_from_short_name(name, nodeInt=1):
+    # Returns a pubkey prefix matching the name
+    for pubkey, contact in _contacts.items():
+        if contact.get('name', '').lower() == name.lower():
+            return pubkey
+    return None
+```
+
+**Replace** `decimal_to_hex(decimal_number)`:
+```python
+def pubkey_short(pubkey):
+    """Returns the 12-char prefix used as the short public identity."""
+    return pubkey[:12] if pubkey else '?'
+```
+> Update all call sites of `decimal_to_hex()` to use `pubkey_short()` or display the prefix directly.
+
+**Replace** `get_node_list()`:
+```python
+def get_node_list(nodeInt=1):
+    if not _contacts:
+        return ERROR_FETCHING_DATA
+    recent = sorted(_contacts.values(), key=lambda c: c.get('last_seen', 0), reverse=True)
+    lines = [f"{c.get('name', '?')} SNR:{c.get('last_snr', 0)}" for c in recent[:SITREP_NODE_COUNT]]
+    return "\n".join(lines)
+```
+
+**Replace** `get_node_location(nodeID, nodeInt, channel, round_digits)`:
+```python
+def get_node_location(pubkey, nodeInt=1, channel=0, round_digits=2):
+    contact = _get_contact(pubkey)
+    if contact and contact.get('lat') and contact.get('lat') != 0.0:
+        lat, lon = contact['lat'], contact['lon']
+        if fuzzItAll:
+            lat, lon = round(lat, round_digits), round(lon, round_digits)
+        return [lat, lon]
+    if fuzz_config_location:
+        return [round(latitudeValue, round_digits), round(longitudeValue, round_digits)]
+    return [latitudeValue, longitudeValue]
+```
+
+#### 1f. Channel cache
+
+**Remove**: `build_channel_cache()`, `refresh_channel_cache()`, `resolve_channel_name()`, `channel_list`.
+
+For DM-only mode, channel sends are not the primary path. Add a simple channel slot tracker:
+```python
+_channel_slots: dict[str, int] = {}
+# key = channel name; value = slot index
+
+async def ensure_channel_slot(channel_name: str, channel_key: str, preferred_slot: int) -> int:
+    """Load a channel into a radio slot if not already loaded."""
+    if channel_name in _channel_slots:
+        return _channel_slots[channel_name]
+    await _mc.commands.set_channel(preferred_slot, channel_name, channel_key)
+    _channel_slots[channel_name] = preferred_slot
+    return preferred_slot
+```
+
+Reference: `../Remote-Terminal-for-MeshCore/app/services/message_send.py` channel slot logic.
+
+#### 1g. `onDisconnect()` / reconnect
+
+**Remove**: `onDisconnect(interface)` (Meshtastic callback).
+
+**Add**: Async reconnect monitor (called from `main()` as a background task):
+```python
+_connected = False
+
+async def connection_monitor():
+    global _mc, _connected
+    while True:
+        await asyncio.sleep(5)
+        if _mc is None or not _connected:
+            logger.warning("System: Radio disconnected, attempting reconnect...")
+            try:
+                await connect_radio()
+                await fetch_own_identity()
+                await register_event_handlers()
+                _connected = True
+                logger.info("System: Reconnected to radio")
+            except Exception as e:
+                logger.error(f"System: Reconnect failed: {e}")
+                _connected = False
+```
+
+Reference: `../Remote-Terminal-for-MeshCore/app/radio.py` — `_connection_monitor()`
+
+#### 1h. Telemetry / firmware / favorites
+
+- `displayNodeTelemetry()`: stub — MeshCore has `get_device_info()`, but the Meshtastic telemetry fields (channelUtilization, airUtilTx) are not equivalent. Simplify to return what's available or log only.
+- `getNodeFirmware()`: Use `mc.commands.get_device_info()` to get firmware version.
+- `handleFavoriteNode()` / `getFavoriteNodes()`: MeshCore has no direct favorites API for the bot. Remove or stub.
+
+---
+
+### Phase 2 — Event Handler (`mesh_bot.py`)
+
+#### 2a. Remove PyPubSub
+
+**Remove**:
+```python
+from pubsub import pub
+# and in start_rx():
+pub.subscribe(onReceive, 'meshtastic.receive')
+pub.subscribe(onDisconnect, 'meshtastic.connection.lost')
+```
+
+#### 2b. Replace `onReceive(packet, interface)`
+
+The current Meshtastic `onReceive` receives a raw packet dict. Replace with two MeshCore event handlers:
+
+**Primary path — raw packet (preferred, gives SNR/RSSI/path)**:
+```python
+async def on_rx_log_data(event):
+    """Primary inbound path via raw RF packet."""
+    # Parse SNR, RSSI, path (hop count) from raw bytes
+    # See ../Remote-Terminal-for-MeshCore/app/packet_processor.py for full decode
+    from modules.system import _mc, _my_public_key, _contacts
+    payload = event.payload
+    raw_bytes = payload.data if hasattr(payload, 'data') else bytes(payload)
+    
+    # Use decoder from Remote-Terminal to extract PacketInfo
+    # packet_info.rssi, packet_info.snr, packet_info.path_len
+    # packet_info.payload_type (PayloadType.PRIV or GroupText)
+    # ... then call _dispatch_message(text, sender_key, snr, rssi, hop, is_dm)
+```
+
+**Fallback path — decoded DM (no raw packet access)**:
+```python
+async def on_contact_message(event):
+    """Fallback DM handler when RX_LOG_DATA is not available."""
+    payload = event.payload
+    sender_key = payload.pubkey_prefix   # 12-char hex
+    text = payload.text
+    await _dispatch_dm(text, sender_key, snr=0, rssi=0, hop="Direct", is_dm=True)
+```
+
+Reference: `../Remote-Terminal-for-MeshCore/app/event_handlers.py` — `on_contact_message()`  
+Reference: `../Remote-Terminal-for-MeshCore/app/packet_processor.py` — `process_raw_packet()`
+
+#### 2c. `_dispatch_dm()` — the new core dispatcher
+
+Extract the DM-handling logic from the current monolithic `onReceive()` into a focused async function:
+```python
+async def _dispatch_dm(text, sender_key, snr, rssi, hop, channel_number=0, device_id=1):
+    global seenNodes, cmdHistory
+    
+    # Update seenNodes (now keyed on pubkey string)
+    _update_seen_nodes(sender_key, channel_number)
+
+    # BBS DM mail delivery
+    if bbs_enabled:
+        msg = bbs_check_dm(sender_key)
+        if msg:
+            await send_message(f"Mail: {msg[1]}  From: {get_name_from_number(msg[2])}", 0, sender_key, device_id)
+            bbs_delete_dm(msg[0], msg[1])
+
+    # Ban check
+    if str(sender_key) in bbs_ban_list or str(sender_key) in autoBanlist:
+        return
+
+    # Safety check
+    if not stringSafeCheck(text, sender_key):
+        return
+
+    # Ignore own messages
+    if sender_key == _my_public_key or sender_key.startswith(_my_public_key[:12]):
+        return
+
+    # Dispatch to auto_response
+    if messageTrap(text) or (games_enabled and checkPlayingGame(sender_key, text, device_id, channel_number)):
+        response = auto_response(text, snr, rssi, hop, (False, sender_key), sender_key, channel_number, device_id, True)
+        if response:
+            await send_message(response, 0, sender_key, device_id)
+    elif llm_enabled and llmReplyToNonCommands:
+        response = handle_llm(sender_key, channel_number, device_id, text, publicChannel)
+        if response:
+            await send_message(response, 0, sender_key, device_id)
+    else:
+        # Welcome / help
+        if not any(n['nodeID'] == sender_key and n.get('welcome') for n in seenNodes):
+            await send_message(welcome_message, 0, sender_key, device_id)
+            for n in seenNodes:
+                if n['nodeID'] == sender_key:
+                    n['welcome'] = True
+```
+
+#### 2d. Register event handlers
+
+```python
+async def register_event_handlers():
+    _mc.subscribe(EventType.RX_LOG_DATA, on_rx_log_data)
+    _mc.subscribe(EventType.CONTACT_MSG_RECV, on_contact_message)
+    _mc.subscribe(EventType.ACK, on_ack)
+    logger.debug("System: Event handlers registered")
+```
+
+Also subscribe to contact events to build the `_contacts` cache:
+```python
+async def on_contact_update(event):
+    contact = event.payload
+    pubkey = contact.public_key or contact.pubkey_prefix
+    _contacts[pubkey] = {
+        'name': contact.name or pubkey[:12],
+        'lat': getattr(contact, 'lat', 0.0),
+        'lon': getattr(contact, 'lon', 0.0),
+        'last_seen': time.time(),
+        'last_snr': getattr(contact, 'last_snr', 0),
+    }
+```
+
+Reference: `../Remote-Terminal-for-MeshCore/app/event_handlers.py` — contact upsert logic.
+
+#### 2e. Replace `start_rx()`
+
+**Remove**:
+```python
+async def start_rx():
+    pub.subscribe(onReceive, 'meshtastic.receive')
+    pub.subscribe(onDisconnect, 'meshtastic.connection.lost')
+    while True:
+        await asyncio.sleep(0.5)
+```
+
+**Replace with** event-driven startup in `main()`:
+```python
+async def main():
+    await connect_radio()
+    await fetch_own_identity()
+    await register_event_handlers()
+    # sync contacts on startup
+    await _mc.commands.get_contacts()
+    # ... then create background tasks as before
+```
+
+---
+
+### Phase 3 — Node Identity Adaptation
+
+This is the widest-touching change. Every place the code uses `message_from_id` as an integer node number must accept a string public key.
+
+#### 3a. `seenNodes`
+
+**Before**: `{'nodeID': 2813308004, 'rxInterface': 1, 'channel': 0, 'welcome': False, ...}`  
+**After**: `{'nodeID': 'aabbccdd1234', 'rxInterface': 1, 'channel': 0, 'welcome': False, ...}`
+
+The `nodeID` key value changes from `int` to `str` (12-char pubkey prefix). No structural change needed.
+
+#### 3b. Game trackers
+
+All game trackers use `nodeID` as a key (or `userID` for DopeWars):
+- `dwPlayerTracker`: `{'userID': sender_key, ...}`
+- `jackTracker`, `vpTracker`, `lemonadeTracker`, `golfTracker`, `hangmanTracker`, `hamtestTracker`, `tictactoeTracker`, `mindTracker`, `battleshipTracker`, `surveyTracker`: `{'nodeID': sender_key, ...}`
+
+No structural changes needed — the keys become strings instead of ints, which Python handles naturally.
+
+#### 3c. Admin and ban lists
+
+`bbs_admin_list` and `bbs_ban_list` are loaded from `config.ini` as comma-separated values. Users will need to provide **12-char public key prefixes** (or full keys) instead of Meshtastic node numbers.
+
+Update `config.template`:
+```ini
+[bbs]
+# bbs_admin_list: comma-separated MeshCore public key prefixes (12 hex chars)
+# example: bbs_admin_list = aabbccdd1234,112233445566
+bbs_admin_list =
+bbs_ban_list =
+```
+
+Update `isNodeAdmin()` and `isNodeBanned()`:
+```python
+def isNodeAdmin(pubkey):
+    pubkey_prefix = str(pubkey)[:12].lower()
+    for admin in bbs_admin_list:
+        if admin.strip().lower() == pubkey_prefix or str(pubkey).lower().startswith(admin.strip().lower()):
+            return True
+    return False
+```
+
+#### 3d. BBS system (`modules/bbstools.py`)
+
+BBS stores messages and DMs keyed on node identifiers. Audit `bbstools.py` for any `int()` casts or numeric-only assumptions on node IDs. Change storage key to string pubkey prefix.
+
+#### 3e. `handle_whoami()` display
+
+**Before**: Shows integer ID, longName, shortName, `!hex` format  
+**After**: Shows pubkey prefix, name from contact cache
+```python
+def handle_whoami(message_from_id, deviceID, hop, snr, rssi, pkiStatus):
+    name = get_name_from_number(message_from_id)
+    prefix = message_from_id[:12] if message_from_id else '?'
+    msg = f"You are {name} key:{prefix}\n"
+    msg += f"SNR:{snr} RSSI:{rssi} {hop}"
+    loc = get_node_location(message_from_id, deviceID)
+    if loc != [latitudeValue, longitudeValue]:
+        msg += f"\nGPS: {loc[0]}, {loc[1]}"
+    return msg
+```
+
+#### 3f. `handle_whois()`
+
+**Before**: Looks up by short name or `!hex` integer  
+**After**: Looks up by name in `_contacts` or by pubkey prefix
+
+---
+
+### Phase 4 — Signal Info (SNR / RSSI / Hop)
+
+#### 4a. SNR and RSSI from raw packets
+
+MeshCore delivers SNR and RSSI via `RX_LOG_DATA`. The decoder in Remote-Terminal extracts them:
+
+Reference: `../Remote-Terminal-for-MeshCore/app/decoder.py` — `parse_packet()` returns `PacketInfo` with `rssi: int`, `snr: float`.
+
+For the bot, either:
+1. **Copy the relevant decoder function** from `Remote-Terminal-for-MeshCore/app/decoder.py` into `modules/decoder.py` (minimal subset).
+2. **Or** fall back to `snr=0, rssi=0` from `CONTACT_MSG_RECV` and only populate them when `RX_LOG_DATA` provides them.
+
+#### 4b. Hop count
+
+**Before**: Computed from `hopStart`, `hopLimit`, `hopsAway` fields in the Meshtastic packet.  
+**After**: `path_len` from `PacketInfo` (from `parse_packet()` on `RX_LOG_DATA`).
+
+Map:
+- `path_len == 0` → `"Direct"` (direct RF)
+- `path_len == 1` → `"1 Hop"`
+- `path_len > 1` → `"N Hops"`
+
+The `handle_ping()` response format (`[RF]`, `[F]`, `[GW]`) maps to:
+- `"Direct"` → `[RF]`
+- `"N Hops"` → `[F]` (flooded)
+- Gateway/MQTT cases are less common in MeshCore — default to `[F]`
+
+---
+
+### Phase 5 — Async Propagation
+
+The current `send_message()` is synchronous and uses `time.sleep()`. After Phase 1 makes it async, every caller must `await` it.
+
+**Callers to update** (all in `mesh_bot.py`):
+- `onReceive()` body → `_dispatch_dm()` (already async in Phase 2)
+- All `handle_*()` functions that call `send_message()` directly (not via `auto_response()`) — e.g., `handle_emergency()`, `handleBattleship()` (P2P notify), `quizHandler()` (broadcast)
+- Background tasks: `handleAlertBroadcast()`, `handleMultiPing()`, scheduler loop
+
+**Strategy**: Make `auto_response()` return a string as before (it does not call `send_message()` itself). Only the callers of `send_message()` outside of `auto_response()` need to become async. There are ~10 such places.
+
+**Replace** all `time.sleep(splitDelay)` → `await asyncio.sleep(splitDelay)` in async contexts.
+
+---
+
+### Phase 6 — Reconnect & Watchdog
+
+#### 6a. Watchdog task
+
+The current `watchdog()` in `mesh_bot.py` handles periodic tasks (multi-ping, alert broadcasts, memory cleanup, scheduler checks). Keep this structure. Replace the interface-check logic:
+
+**Before**:
+```python
+# Check if interfaces are alive (Meshtastic-specific)
+for i in range(1, 10):
+    if interface[i] and not interface[i].isConnected():
+        ...
+```
+
+**After**:
+```python
+# Check MeshCore connection
+if not _connected:
+    logger.warning("Watchdog: Radio not connected")
+    # connection_monitor() task handles reconnect
+```
+
+#### 6b. Connection monitor
+
+Already defined in Phase 1g. Add it as a named asyncio task in `main()`:
+```python
+tasks.append(asyncio.create_task(connection_monitor(), name="connection_monitor"))
+```
+
+---
+
+### Phase 7 — Pong Bot (`pong_bot.py`)
+
+`pong_bot.py` is a stripped-down version of `mesh_bot.py`. Apply the same changes:
+- Remove `pub.subscribe`
+- Replace `onReceive` with MeshCore event handlers
+- Replace `interface.sendText()` with `await mc.commands.send_msg()`
+- Remove interface init loop
+
+Because the pong bot is simpler, tackle it after `mesh_bot.py` is working.
+
+---
+
+### Phase 8 — Scheduler Module (`modules/scheduler.py`)
+
+The scheduler calls `send_message()` to broadcast timed messages. After Phase 5, update calls to `await send_message()`. Scheduler must run inside the asyncio event loop (it already does via `run_scheduler_loop()` task).
+
+---
+
+### Phase 9 — Testing
+
+- [ ] Run `python3 -m pytest modules/test_bot.py -v` — module import tests should still pass (no radio needed)
+- [ ] Connect a MeshCore radio and run `mesh_bot.py` — verify DM receive and respond
+- [ ] Test `ping` command: verify SNR/RSSI/hop display
+- [ ] Test `whoami`: verify pubkey prefix display
+- [ ] Test BBS: `bbspost`, `bbsread`, `bbslist`
+- [ ] Test a game: `blackjack`
+- [ ] Test admin command with a key in `bbs_admin_list`
+
+---
+
+## Files Changed Summary
+
+| File | Change |
+|---|---|
+| `requirements.txt` | Remove `meshtastic`, `PyPubSub`; add `meshcore`, `pycryptodome` |
+| `config.template` | Update `[interface]` section; update admin/ban list format |
+| `modules/system.py` | Full radio layer rewrite (Phases 1a–1h) |
+| `modules/settings.py` | Remove Meshtastic-specific defaults |
+| `mesh_bot.py` | Replace event subscription and onReceive (Phase 2); async propagation (Phase 5) |
+| `pong_bot.py` | Same as mesh_bot.py, simpler (Phase 7) |
+| `modules/scheduler.py` | Await send_message (Phase 8) |
+| `modules/bbstools.py` | String node IDs (Phase 3d) |
+| `modules/decoder.py` | New file — minimal decoder for SNR/RSSI/hop from RX_LOG_DATA (Phase 4) |
+| `modules/test_bot.py` | Update for new identity model (Phase 9) |
+
+**Files that do NOT change**: All game modules, weather modules, LLM, BBS logic, wiki, RSS, etc. The feature layer is untouched.
+
+---
+
+## Reference Checklist (grep targets before starting each phase)
+
+```bash
+# All Meshtastic imports
+grep -rn "import meshtastic" meshing-around-mc/
+
+# All pubsub uses
+grep -rn "from pubsub\|pub.subscribe" meshing-around-mc/
+
+# All interface object uses (beyond system.py)
+grep -rn "interface\." meshing-around-mc/modules/
+
+# All send_message calls (to update to await)
+grep -rn "send_message(" meshing-around-mc/
+
+# All decimal_to_hex calls (to replace with pubkey_short)
+grep -rn "decimal_to_hex" meshing-around-mc/
+
+# All get_name_from_number calls
+grep -rn "get_name_from_number" meshing-around-mc/
+
+# All isNodeAdmin / isNodeBanned calls
+grep -rn "isNodeAdmin\|isNodeBanned" meshing-around-mc/
+```

--- a/modules/bbstools.md
+++ b/modules/bbstools.md
@@ -1,9 +1,9 @@
 
 ---
 
-# 📡 meshBBS: How-To & API Documentation
+# meshBBS: How-To & Documentation
 
-This document covers the Bulliten Board System or BBS componment of the meshing-around project.
+This document covers the Bulletin Board System (BBS) component of the meshing-around bot, including the **bbslink** feature for syncing posts between two bots over the air (OTA).
 
 ## Table of Contents
 
@@ -11,224 +11,284 @@ This document covers the Bulliten Board System or BBS componment of the meshing-
     - [Central Message Store](#11-central-message-store)
     - [Direct Mail (DM) Messages](#12-direct-mail-dm-messages)
     - [BBS Commands](#bbs-commands)
-2. [Synchronization bot2bot: Full Sync Workflow](#2-synchronization-bot2bot--full-sync-workflow)
-    - [BBS Database Sync: File-Based (Out-of-Band)](#21-bbs-database-sync-file-based-out-of-band)
-    - [BBS Over-the-Air (OTA) Sync: Linking](#22-bbs-over-the-air-ota-sync-linking)
-    - [Scheduling BBS Auto Sync](#23-scheduling-bbs-auto-sync)
-3. [Troubleshooting](#4-troubleshooting)
-4. [API Reference: BBS Sync](#5-api-reference-bbs-sync)
-5. [Best Practices](#5-best-practices)
+2. [BBSLink: OTA Sync Between Bots](#2-bbslink-ota-sync-between-bots)
+    - [Overview](#21-overview)
+    - [Prerequisites](#22-prerequisites)
+    - [Configuration](#23-configuration)
+    - [Finding a Peer's Pubkey Prefix](#24-finding-a-peers-pubkey-prefix)
+    - [Access Modes](#25-access-modes)
+    - [How the Sync Protocol Works](#26-how-the-sync-protocol-works)
+    - [What to Expect](#27-what-to-expect)
+3. [Automatic Sync with the Scheduler](#3-automatic-sync-with-the-scheduler)
+4. [Manual Sync Trigger](#4-manual-sync-trigger)
+5. [BBS Database Sync: File-Based (Out-of-Band)](#5-bbs-database-sync-file-based-out-of-band)
+6. [Troubleshooting](#6-troubleshooting)
+7. [API Reference](#7-api-reference)
 
-## 1. **BBS Core Functions**
-The mesh-bot provides a basic message mail system for Meshtastic
+---
 
-## 1.1 Central Message Store
+## 1. BBS Core Functions
 
-- **Shared public message space** for all nodes.
-- Classic BBS list with a simple, one-level message tree.
+### 1.1 Central Message Store
+
+- Shared public message board for all nodes on the mesh.
+- Simple one-level message list — no threading.
 - Messages are stored in `data/bbsdb.pkl`.
-- Each entry typically includes:  
-  `[id, subject, body, fromNode, timestamp, threadID, replytoID]`
+- Each entry: `[id, subject, body, fromNode, timestamp, threadID, replytoID]`
 
-### Posting to Public
-
-To post a public message:
-```sh
-bbspost $Subject #Message
+**Post a public message:**
+```
+bbspost $Subject #Message body here
 ```
 
----
+### 1.2 Direct Mail (DM) Messages
 
-## 1.2 Direct Mail (DM) Messages
-- **DMs are private messages** sent from one node to another.
-- Stored separately from public posts in `data/bbsdm.pkl`.
-- Each DM entry typically includes:  
-  `[id, toNode, message, fromNode, timestamp, threadID, replytoID]`
-- You can inject DMs directly for automation using the `script/injectDM.py` tool.
+- Private messages from one node to another, stored in `data/bbsdm.pkl`.
+- When the recipient node comes online, the bot delivers the DM and removes it from storage.
+- Each DM entry: `[toNode, message, fromNode]`
 
-### DM Delivery
-
-- To post a DM, use:  
-  ```sh
-  bbspost @USER #Message
-  ```
-- When a DM is posted, it is added to the DM database.
-- When the bot detects the recipient node on the network, it delivers the DM and then removes it from local storage.
-
----
+**Post a DM:**
+```
+bbspost @Username #Message body here
+```
 
 ### BBS Commands
 
-| Command      | Description                                   |
-|--------------|-----------------------------------------------|
-| `bbshelp`    | Show BBS help                                 |
-| `bbslist`    | List messages                                 |
-| `bbsread`    | Read a message by ID                          |
-| `bbspost`    | Post a message or DM                          |
-| `bbsdelete`  | Delete a message                              |
-| `bbsinfo`    | BBS stats (sysop)                             |
-| `bbslink`    | Link messages between BBS systems             |
+| Command      | Description                            |
+|--------------|----------------------------------------|
+| `bbshelp`    | Show BBS help                          |
+| `bbslist`    | List all public message subjects       |
+| `bbsread #N` | Read public message by ID              |
+| `bbspost`    | Post a public message or send a DM     |
+| `bbsdelete #N` | Delete a message (owner or admin)    |
+| `bbsinfo`    | Show message and DM counts             |
 
 ---
 
-## 2. **Synchronization bot2bot : Full Sync Workflow**
+## 2. BBSLink: OTA Sync Between Bots
 
-1. **Set up a dedicated sync channel** (e.g., channel bot-admin).
-2. **Configure both nodes** with `bbs_link_enabled = True` and add each other to `bbs_link_whitelist`.
-3. **Schedule sync** every hour:
-   - Node A sends `bbslink 0` to Node B on channel 99.
-   - Node B responds with messages and `bbsack`.
-4. **Optionally, use SSH/scp** to copy `bbsdb.pkl` for full out-of-band backup.
+### 2.1 Overview
 
+BBSLink lets two MeshBot instances exchange their public BBS posts over the air, one post at a time, using DM messages. A sync session pulls all posts from a peer bot into your local board. Duplicate posts are silently ignored, so you can run sync repeatedly without building up duplicates.
 
-## 2.1. **BBS Database Sync: File-Based (Out-of-Band)**
+Sync is **one-directional per session**: the initiating bot pulls from the peer. For bidirectional sync, configure both bots to pull from each other on a schedule.
 
-### **Manual/Automated File Sync (e.g., SSH/SCP)**
-- **Purpose:** Sync BBS data between nodes by copying `bbsdb.pkl` and `bbsdm.pkl` files.
+### 2.2 Prerequisites
+
+- Both bots must be running MeshCore (this feature does not work with Meshtastic).
+- Both bots must have `[bbs] enabled = True` in `config.ini`.
+- The **receiving** bot (the one being pulled from) must have `bbslink_enabled = True`.
+- Both bots must be reachable via DM on the mesh.
+
+### 2.3 Configuration
+
+Add the following to the `[bbs]` section of `config.ini` on each bot:
+
 ```ini
 [bbs]
-# The "api" needs enabled which enables file polling 
-bbsAPI_enabled = True 
+enabled = True
+bbslink_enabled = True
+
+# Peer BBS bots to sync with (comma-separated pubkey prefixes, 12-char hex).
+# Also acts as the inbound whitelist — only listed nodes may sync with this bot.
+# Leave empty to allow any node to sync (open mode).
+bbslink_peers = a1b2c3d4e5f6,b2c3d4e5f6a7
 ```
-- **How-To:**
-  1. **Locate Files:**  
-     - `data/bbsdb.pkl` (public posts)
-     - `data/bbsdm.pkl` (direct messages)
-  2. **Copy Files:**  
-     Use `scp` or `rsync` to copy files between nodes:
-     ```sh
-     scp user@remote:/path/to/meshing-around/data/bbsdb.pkl ./data/bbsdb.pkl
-     scp user@remote:/path/to/meshing-around/data/bbsdm.pkl ./data/bbsdm.pkl
-     ```
-  3. **Reload Database:**  
-     After copying, when the "API" is enabled the watchdog will look for changes and injest.
 
-- **Automating with Cron/Scheduler:**
-  - Set up a cron job or use the bot’s scheduler to periodically pull/push files.
+**Bot A config** — wants to pull from Bot B:
+```ini
+bbslink_enabled = True
+bbslink_peers = <Bot B's pubkey prefix>
+```
+
+**Bot B config** — the source of posts:
+```ini
+bbslink_enabled = True
+bbslink_peers = <Bot A's pubkey prefix>   # restricts inbound; omit to allow all
+```
+
+### 2.4 Finding a Peer's Pubkey Prefix
+
+MeshCore identifies nodes by a **12-character hex pubkey prefix** (e.g. `a1b2c3d4e5f6`). This is visible in:
+
+- The MeshCore web interface or Remote Terminal — shown in the contacts list next to a node's name.
+- Bot logs — when a node sends a message, its pubkey prefix is logged: `From: a1b2c3d4e5f6`
+- The `whoami` or `whois` bot command — returns identity info including the pubkey prefix.
+
+This is **not** the same as a Meshtastic numeric node ID.
+
+### 2.5 Access Modes
+
+| `bbslink_peers` value | Behavior |
+|-----------------------|----------|
+| Empty (default)       | **Open mode** — any node can initiate a sync with this bot |
+| One or more prefixes  | **Closed mode** — only listed nodes can sync; others get "BBS Link is disabled for your node" |
+
+`bbslink_peers` serves double duty: it's both the list of peers the scheduler actively contacts, and the inbound access control list.
+
+### 2.6 How the Sync Protocol Works
+
+Sync is driven by a DM ping-pong exchange:
+
+```
+Initiator (Bot A)          Peer (Bot B)
+─────────────────          ────────────
+bbslink 0          →       (receives request)
+                   ←       bbslink 0 $Subject #Body @originPrefix
+bbsack 0           →       (acknowledges, peer sends next)
+                   ←       bbslink 1 $Subject2 #Body2 @originPrefix2
+bbsack 1           →
+                   ←       bbslink 2 $...
+...
+bbsack N           →       (N+1 >= total messages — sync complete, no reply)
+```
+
+**Rate limiting** — the peer bot paces its replies to avoid mesh congestion:
+- 5 seconds (+ `responseDelay`) between each message
+- An additional 10 second pause every 5 messages
+
+So a board with 20 posts takes roughly **2–3 minutes** to fully sync.
+
+**Message format** (internal, not user-typed):
+```
+bbslink <N> $<subject> #<body> @<originPubkeyPrefix>
+```
+
+**ACK format:**
+```
+bbsack <N>
+```
+
+### 2.7 What to Expect
+
+- Sync pulls **all posts from the peer's board**, starting at index 0.
+- Posts already on your board with the same subject and body are silently skipped (dedup by content hash).
+- The origin author of a synced post is preserved — the `@originPrefix` field in the wire format stores who originally wrote it.
+- While a sync is in progress the bot remains responsive to other commands — the async delays do not block the event loop.
+- Channel bbslink messages also work (for broadcast-mode discovery). The bot always replies via DM, not on the channel, to avoid spamming it.
 
 ---
 
-## 2.2. **BBS Over-the-Air (OTA) Sync: Linking**
-### **How OTA Sync Works**
-- Nodes can exchange BBS messages using special commands over the mesh network.
-- Uses `bbslink` and `bbsack` commands for message exchange.
-- Future supports compression for bandwidth efficiency.
+## 3. Automatic Sync with the Scheduler
 
-### **Enabling BBS Linking**
-- Set `bbs_link_enabled = True` in your config.
-- Optionally, set `bbs_link_whitelist` to restrict which nodes can sync.
+Use the `link` scheduler value to have the bot initiate sync automatically on a recurring schedule.
 
-### **Manual Sync Command**
-- To troubleshoot request sync from another node, send:
-  ```
-  bbslink <messageID> $<subject> #<body>
-  ```
-- The receiving node will respond with `bbsack <messageID>`.
-
-### **Out-of-Band Channel**
-- For high-reliability sync, configure a dedicated channel (not used for chat).
----
-
-## 2.3. **Scheduling BBS Auto Sync**
-
-### **Using the Bot’s Scheduler**
-
-- You can schedule periodic sync requests to a peer node.
-- Example: Every hour, send a `bbslink` request to a peer.
-see more at [Module Readme](README.md#scheduler)
-
----
-
-#### BBS Link
-The scheduler also handles the BBS Link Broadcast message, this would be an example of a mesh-admin channel on 8 being used to pass BBS post traffic between two bots as the initiator, one direction pull. The message just needs to have bbslink
-
+**With `bbslink_peers` configured** — sends `bbslink 0` as a DM to each peer:
 ```ini
 [bbs]
 bbslink_enabled = True
-bbslink_whitelist = # list of whitelisted nodes numbers ex: 2813308004,4258675309 empty list allows all
+bbslink_peers = a1b2c3d4e5f6
 
 [scheduler]
 enabled = True
 interface = 1
-channel = 2
+channel = 0       # channel is unused for DM mode but required
 value = link
-interval = 12 # 12 hours
+interval = 6      # every 6 hours
 ```
 
-```python
-# Custom Schedule Example if using custom for [scheduler]
-# Send bbslink looking for peers every 2 days at 10 AM
-schedule.every(2).days.at("10:00").do(send_message("bbslink MeshBot looking for peers", schedulerChannel, 0, schedulerInterface))
-```
-
----
-
----
-
-## 4. **Troubleshooting**
-
-- **Messages not syncing?**
-  - Check `bbs_link_enabled` and whitelist settings.
-  - Ensure both nodes are on the same sync channel.
-  - Check logs for errors.
-
-- **File sync issues?**
-  - Verify file permissions and paths.
-  - Ensure the bot reloads the database after file copy.
-
-- **Custom file problems?**
-- remove the custom_scheduler.py and replace it with [etc/custom_scheduler.py](etc/custom_scheduler.py)
-
- The bbs link command should include `bbslink`
-`.do(send_message("bbslink MeshBot looking for peers", schedulerChannel, 0, schedulerInterface))`
-
+**Without `bbslink_peers`** (open/broadcast mode) — sends `bbslink MeshBot looking for peers` as a channel message. Any bot with `bbslink_enabled = True` that sees the message will respond and push its posts:
 ```ini
 [bbs]
-# The "api" needs enabled which enables file polling and use of `script/injectDM.py`
-bbsAPI_enabled = True 
+bbslink_enabled = True
+
+[scheduler]
+enabled = True
+interface = 1
+channel = 8       # dedicated mesh-admin channel recommended
+value = link
+interval = 12     # every 12 hours
 ```
 
-## 5. **API Reference: BBS Sync**
-
-### **Key Functions in Python**
-| Function                | Purpose                                   | Usage Example                                      |
-|-------------------------|-------------------------------------------|----------------------------------------------------|
-| `bbs_post_message()`    | Post a new public message                 | `bbs_post_message(subject, body, fromNode)`        |
-| `bbs_read_message()`    | Read a message by ID                      | `bbs_read_message(messageID)`                      |
-| `bbs_delete_message()`  | Delete a message (admin/owner only)       | `bbs_delete_message(messageID, fromNode)`          |
-| `bbs_list_messages()`   | List all message subjects                 | `bbs_list_messages()`                              |
-| `bbs_post_dm()`         | Post a direct message                     | `bbs_post_dm(toNode, message, fromNode)`           |
-| `bbs_check_dm()`        | Check for DMs for a node                  | `bbs_check_dm(toNode)`                             |
-| `bbs_delete_dm()`       | Delete a DM after reading                 | `bbs_delete_dm(toNode, message)`                   |
-| `get_bbs_stats()`       | Get stats on BBS and DMs                  | `get_bbs_stats()`                                  |
-
-
-| Function                  | Purpose                                   |
-|---------------------------|-------------------------------------------|
-| `bbs_sync_posts()`        | Handles incoming/outgoing sync requests   |
-| `bbs_receive_compressed()`| Handles compressed sync data              |
-| `compress_data()`         | Compresses data for OTA transfer          |
-| `decompress_data()`       | Decompresses received data                |
-
-
-### **Handle Incoming Sync**
-- The bot automatically processes incoming `bbslink` and `bbsack` commands via `bbs_sync_posts()`.
-
-### **Compressed Sync**
-Future Use
-- If `useSynchCompression` is enabled, use:
-  ```python
-  compressed = compress_data(msg)
-  send_raw_bytes(peerNode, compressed)
-  ```
-- Receiving node uses `bbs_receive_compressed()`.
+The `interval` is always in **hours**.
 
 ---
-### 5. **Best Practices**
 
-- **Backup:** Regularly back up `bbsdb.pkl` and `bbsdm.pkl`.
-- **Security:** Use SSH keys for file transfer; restrict OTA sync to trusted nodes.
-- **Reliability:** Use a dedicated channel for BBS sync to avoid chat congestion.
-- **Automation:** Use the scheduler for regular syncs, both file-based and OTA.
+## 4. Manual Sync Trigger
+
+To manually pull all posts from a peer bot, send it a DM:
+```
+bbslink 0
+```
+
+The peer will begin sending its posts back to you one at a time. You do not need to send anything else — the ACKs are handled automatically by your bot.
+
+To check if bbslink is working from the peer's side without triggering a full sync, you can also send:
+```
+bbslink MeshBot looking for peers
+```
+The peer will respond with its first post if `bbslink_enabled = True`.
+
+---
+
+## 5. BBS Database Sync: File-Based (Out-of-Band)
+
+For full bulk sync or backup, copy the database files directly between hosts.
+
+Enable the API watcher so the bot picks up externally modified files:
+```ini
+[bbs]
+bbsAPI_enabled = True
+```
+
+**Copy files manually:**
+```sh
+scp user@remote:/path/to/meshing-around-mc/data/bbsdb.pkl ./data/bbsdb.pkl
+scp user@remote:/path/to/meshing-around-mc/data/bbsdm.pkl ./data/bbsdm.pkl
+```
+
+When `bbsAPI_enabled = True`, the watchdog detects file changes and reloads the database automatically. Useful for a nightly cron job or rsync.
+
+You can also inject a DM directly using `script/injectDM.py` without going over the air.
+
+---
+
+## 6. Troubleshooting
+
+**Peer replies "BBS Link is disabled for your node."**
+- The peer has `bbslink_peers` set and your bot's pubkey prefix is not in the list.
+- Add your prefix to the peer's `bbslink_peers`, or clear the list for open mode.
+
+**No response at all to `bbslink 0`**
+- Check that the peer has `bbslink_enabled = True`.
+- Confirm you are sending it as a **DM** to the peer's pubkey prefix, not as a channel message to address `0`.
+- Check the peer's logs for `BBS Link is disabled` or connection errors.
+
+**Sync starts but stops partway through**
+- Normal — if the mesh drops a message, the session stalls. Restart by sending `bbslink 0` again.
+- The bot resumes from the beginning (message 0), but duplicates are skipped, so restarting is safe.
+
+**Posts appear with wrong author names**
+- Author identity is stored as the pubkey prefix at time of original posting. If the name hasn't been seen on your local mesh yet, it will display as the raw prefix until that node advertises itself.
+
+**File sync not reloading after scp**
+- Ensure `bbsAPI_enabled = True`.
+- Confirm the watchdog task is running (check logs for "data persistence" task).
+
+---
+
+## 7. API Reference
+
+### BBS Functions (`modules/bbstools.py`)
+
+| Function | Purpose |
+|---|---|
+| `bbs_post_message(subject, body, fromNode)` | Post a new public message |
+| `bbs_read_message(messageID)` | Read a message by ID |
+| `bbs_delete_message(messageID, fromNode)` | Delete (owner or admin only) |
+| `bbs_list_messages()` | Return formatted subject list |
+| `bbs_post_dm(toNode, message, fromNode)` | Queue a DM for delivery |
+| `bbs_check_dm(toNode)` | Check for pending DM for a node |
+| `bbs_delete_dm(toNode, message)` | Remove a delivered DM |
+| `get_bbs_stats()` | Return post and DM counts |
+| `bbs_sync_posts(input, peerNode, rxNode)` | Handle inbound bbslink/bbsack (async) |
+
+### Compression (future use)
+
+`useSynchCompression = False` in `bbstools.py`. When enabled:
+- `compress_data(msg)` → zlib bytes
+- `bbs_receive_compressed(data_bytes, fromNode, rxNode)` → decompress + sync
+
+Not active in current builds.
 
 ---

--- a/modules/bbstools.py
+++ b/modules/bbstools.py
@@ -1,9 +1,10 @@
 # helper functions for various BBS messaging tasks
 # K7MHI Kelly Keeton 2024
 
+import asyncio
 import pickle # pip install pickle
 from modules.log import logger
-from modules.settings import bbs_admin_list, bbs_ban_list, MESSAGE_CHUNK_SIZE, bbs_link_enabled, bbs_link_whitelist, responseDelay
+from modules.settings import bbs_admin_list, bbs_ban_list, MESSAGE_CHUNK_SIZE, bbs_link_enabled, bbs_link_peers, responseDelay
 import time
 from datetime import datetime
 
@@ -134,10 +135,11 @@ def bbs_read_message(messageID = 0):
     if (messageID - 1) >= len(bbs_messages):
         return "Message not found."
     if messageID > 0:
+        from modules.system import get_name_from_number
         fromNode = bbs_messages[messageID - 1][3]
-        fromNodeHex = hex(fromNode)[-4:]
+        fromName = get_name_from_number(fromNode, 'long') if fromNode else '?'
         message = bbs_messages[messageID - 1]
-        return f"Msg #{message[0]}\nFrom:{fromNodeHex}\n{message[2]}"
+        return f"Msg #{message[0]}\nFrom:{fromName}\n{message[2]}"
     else:
         return "Please specify a message number to read."
    
@@ -159,7 +161,7 @@ def load_bbsdm():
                     if msg not in bbs_dm:
                         bbs_dm.append(msg)
     except:
-        bbs_dm = [[1234567890, "Message", 1234567890]]
+        bbs_dm = [['', 'Message', '']]
         logger.debug("System: Creating new data/bbsdm.pkl")
         with open('data/bbsdm.pkl', 'wb') as f:
             pickle.dump(bbs_dm, f)
@@ -176,11 +178,11 @@ def bbs_post_dm(toNode, message, fromNode):
         return "Message too long, max length is " + str(3 * MESSAGE_CHUNK_SIZE) + " characters."
     # validate not a duplicate message
     for msg in bbs_dm:
-        if msg[0] == int(toNode) and msg[1].strip().lower() == message.strip().lower():
+        if msg[0] == str(toNode) and msg[1].strip().lower() == message.strip().lower():
             return "DM Posted for node " + str(toNode)
 
     # append the message to the list
-    bbs_dm.append([int(toNode), message, int(fromNode)])
+    bbs_dm.append([str(toNode), message, str(fromNode)])
 
     # save the bbsdb
     save_bbsdm()
@@ -195,7 +197,7 @@ def bbs_check_dm(toNode):
     global bbs_dm
     # Check for any messages for toNode
     for msg in bbs_dm:
-        if msg[0] == toNode:
+        if msg[0] == str(toNode):
             return msg
     return False
 
@@ -203,7 +205,7 @@ def bbs_delete_dm(toNode, message):
     global bbs_dm
     # delete a message from the bbsdm
     for msg in bbs_dm:
-        if msg[0] == toNode:
+        if msg[0] == str(toNode):
             # check if the message matches
             if msg[1] == message:
                 bbs_dm.remove(msg)
@@ -238,16 +240,16 @@ def bbs_receive_compressed(data_bytes, fromNode, RxNode):
         logger.error(f"Error decompressing BBS message: {e}")
         return None
 
-def bbs_sync_posts(input, peerNode, RxNode):
+async def bbs_sync_posts(input, peerNode, RxNode):
     messageID =  0
 
     # check if the bbs link is enabled
-    if bbs_link_whitelist != ['']:
-        if str(peerNode) not in bbs_link_whitelist:
-            logger.warning(f"System: BBS Link is disabled for node {peerNode}.")
-            return "System: BBS Link is disabled for your node."
     if bbs_link_enabled == False:
         return "System: BBS Link is disabled."
+    if bbs_link_peers:
+        if str(peerNode) not in bbs_link_peers:
+            logger.warning(f"System: BBS Link is disabled for node {peerNode}.")
+            return "System: BBS Link is disabled for your node."
     
     # respond when another bot asks for the bbs posts to sync
     if "bbslink" in input.lower():
@@ -255,24 +257,21 @@ def bbs_sync_posts(input, peerNode, RxNode):
             #store the message
             subject = input.split("$")[1].split("#")[0]
             body = input.split("#")[1]
-            fromNodeHex = body.split("@")[1]
-            #validate the fromNodeHex is a valid hex number
-            try:
-                int(fromNodeHex, 16)
-            except ValueError:
-                logger.error(f"System: Invalid fromNodeHex in bbslink from node {peerNode}: {input}")
-                fromNodeHex = hex(peerNode)
+            fromNodeHex = body.split("@")[1].strip() if "@" in body else ""
+            if not fromNodeHex:
+                logger.error(f"System: Missing fromNodeHex in bbslink from node {peerNode}: {input}")
+                fromNodeHex = str(peerNode)
             #validate the subject and body are not empty
             if subject.strip() == "" or body.strip() == "":
                 logger.error(f"System: Empty subject or body in bbslink from node {peerNode}: {input}")
                 return "System: Invalid bbslink format."
-            
+
             #store the message in the bbsdb
             try:
-                bbs_post_message(subject, body, int(fromNodeHex, 16))
+                bbs_post_message(subject, body, fromNodeHex)
             except:
                 logger.error(f"System: Error parsing bbslink from node {peerNode}: {input}")
-                fromNodeHex = hex(peerNode)
+                fromNodeHex = str(peerNode)
             messageID = input.split(" ")[1]
             return f"bbsack {messageID}"
     elif "bbsack" in input.lower():
@@ -288,11 +287,11 @@ def bbs_sync_posts(input, peerNode, RxNode):
     # send message with delay to keep chutil happy
     if messageID < len(bbs_messages):
         logger.debug(f"System: wait to bbslink with peer " + str(peerNode))
-        fromNodeHex = hex(bbs_messages[messageID][3])
-        time.sleep(5 + responseDelay)
+        fromNodeHex = str(bbs_messages[messageID][3])
+        await asyncio.sleep(5 + responseDelay)
         # every 5 messages add extra delay
         if messageID % 5 == 0:
-            time.sleep(10 + responseDelay)
+            await asyncio.sleep(10 + responseDelay)
         logger.debug(f"System: Sending bbslink message {messageID} of {len(bbs_messages)} to peer " + str(peerNode))
         msg = f"bbslink {messageID} ${bbs_messages[messageID][1]} #{bbs_messages[messageID][2]} @{fromNodeHex}"
         if useSynchCompression:

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -100,7 +100,7 @@ def setup_scheduler(
         scheduler_message = MOTD if schedulerMotd else schedulerMessage
 
         def send_sched_msg():
-            send_message(scheduler_message, schedulerChannel, 0, schedulerInterface)
+            asyncio.ensure_future(send_message(scheduler_message, schedulerChannel, 0, schedulerInterface))
 
         # Basic Scheduler Options
         basicOptions = ['day', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun', 'hour', 'min']
@@ -142,53 +142,61 @@ def setup_scheduler(
             logger.debug(f"System: Starting the basic scheduler to send '{scheduler_message}' on schedule '{schedulerValue}' every {effective_interval} interval at time '{schedulerTime}' on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'joke' in schedulerValue:
             schedule.every(schedulerIntervalInt).minutes.do(
-                lambda: send_message(tell_joke(), schedulerChannel, 0, schedulerInterface)
+                lambda: asyncio.ensure_future(send_message(tell_joke(), schedulerChannel, 0, schedulerInterface))
             )
             logger.debug(f"System: Starting the joke scheduler to send a joke every {schedulerIntervalInt} minutes on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'link' in schedulerValue:
-            schedule.every(schedulerIntervalInt).hours.do(
-                lambda: send_message("bbslink MeshBot looking for peers", schedulerChannel, 0, schedulerInterface)
-            )
-            logger.debug(f"System: Starting the link scheduler to send link messages every {schedulerIntervalInt} hours on Device:{schedulerInterface} Channel:{schedulerChannel}")
+            from modules.settings import bbs_link_peers
+            if bbs_link_peers:
+                def send_link_to_peers():
+                    for peer in bbs_link_peers:
+                        asyncio.ensure_future(send_message("bbslink 0", schedulerChannel, peer, schedulerInterface))
+                schedule.every(schedulerIntervalInt).hours.do(send_link_to_peers)
+                logger.debug(f"System: Starting the link scheduler, syncing with peers: {bbs_link_peers} every {schedulerIntervalInt}h on Device:{schedulerInterface}")
+            else:
+                schedule.every(schedulerIntervalInt).hours.do(
+                    lambda: asyncio.ensure_future(send_message("bbslink MeshBot looking for peers", schedulerChannel, 0, schedulerInterface))
+                )
+                logger.debug(f"System: Starting the link scheduler (broadcast mode) every {schedulerIntervalInt}h on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'weather' in schedulerValue:
             schedule.every().day.at(schedulerTime).do(
-                lambda: send_message(handle_wxc(0, schedulerInterface, 'wx', days=1), schedulerChannel, 0, schedulerInterface)
+                lambda: asyncio.ensure_future(send_message(handle_wxc(0, schedulerInterface, 'wx', days=1), schedulerChannel, 0, schedulerInterface))
             )
             logger.debug(f"System: Starting the weather scheduler to send weather updates every {schedulerIntervalInt} hours on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'news' in schedulerValue:
             schedule.every(schedulerIntervalInt).hours.do(
-                lambda: send_message(handleNews(0, schedulerInterface, 'readnews', False), schedulerChannel, 0, schedulerInterface)
+                lambda: asyncio.ensure_future(send_message(handleNews(0, schedulerInterface, 'readnews', False), schedulerChannel, 0, schedulerInterface))
             )
             logger.debug(f"System: Starting the news scheduler to send news updates every {schedulerIntervalInt} hours on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'readrss' in schedulerValue:
             schedule.every(schedulerIntervalInt).hours.do(
-                lambda: send_message(get_rss_feed(''), schedulerChannel, 0, schedulerInterface)
+                lambda: asyncio.ensure_future(send_message(get_rss_feed(''), schedulerChannel, 0, schedulerInterface))
             )
             logger.debug(f"System: Starting the RSS scheduler to send RSS feeds every {schedulerIntervalInt} hours on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'mwx' in schedulerValue:
             schedule.every().day.at(schedulerTime).do(
-                lambda: send_message(handle_mwx(0, schedulerInterface, 'mwx'), schedulerChannel, 0, schedulerInterface)
+                lambda: asyncio.ensure_future(send_message(handle_mwx(0, schedulerInterface, 'mwx'), schedulerChannel, 0, schedulerInterface))
             )
             logger.debug(f"System: Starting the marine weather scheduler to send marine weather updates at {schedulerTime} on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'sysinfo' in schedulerValue:
             schedule.every(schedulerIntervalInt).hours.do(
-                lambda: send_message(sysinfo('', 0, schedulerInterface, False), schedulerChannel, 0, schedulerInterface)
+                lambda: asyncio.ensure_future(send_message(sysinfo('', 0, schedulerInterface, False), schedulerChannel, 0, schedulerInterface))
             )
             logger.debug(f"System: Starting the sysinfo scheduler to send system information every {schedulerIntervalInt} hours on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'tide' in schedulerValue:
             schedule.every().day.at(schedulerTime).do(
-                lambda: send_message(handle_tide(0, schedulerInterface, schedulerChannel), schedulerChannel, 0, schedulerInterface)
+                lambda: asyncio.ensure_future(send_message(handle_tide(0, schedulerInterface, schedulerChannel), schedulerChannel, 0, schedulerInterface))
             )
             logger.debug(f"System: Starting the tide scheduler to send tide information at {schedulerTime} on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'solar' in schedulerValue:
             schedule.every().day.at(schedulerTime).do(
-                lambda: send_message(handle_sun(0, schedulerInterface, schedulerChannel), schedulerChannel, 0, schedulerInterface)
+                lambda: asyncio.ensure_future(send_message(handle_sun(0, schedulerInterface, schedulerChannel), schedulerChannel, 0, schedulerInterface))
             )
             logger.debug(f"System: Starting the scheduler to send solar information at {schedulerTime} on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'verse' in schedulerValue:
             from modules.filemon import read_verse
             schedule.every().day.at(schedulerTime).do(
-                lambda: send_message(read_verse(), schedulerChannel, 0, schedulerInterface)
+                lambda: asyncio.ensure_future(send_message(read_verse(), schedulerChannel, 0, schedulerInterface))
             )
             logger.debug(f"System: Starting the verse scheduler to send a verse at {schedulerTime} on Device:{schedulerInterface} Channel:{schedulerChannel}")
         elif 'custom' in schedulerValue:

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -377,7 +377,7 @@ try:
     bbs_ban_list = config['bbs'].get('bbs_ban_list', '').split(',')
     bbs_admin_list = config['bbs'].get('bbs_admin_list', '').split(',')
     bbs_link_enabled = config['bbs'].getboolean('bbslink_enabled', False)
-    bbs_link_whitelist = config['bbs'].get('bbslink_whitelist', '').split(',')
+    bbs_link_peers = [p.strip() for p in config['bbs'].get('bbslink_peers', '').split(',') if p.strip()]
     bbsAPI_enabled = config['bbs'].getboolean('bbsAPI_enabled', False)
     
     # checklist

--- a/modules/system.py
+++ b/modules/system.py
@@ -1,9 +1,7 @@
 # helper functions and init for system related tasks
 # K7MHI Kelly Keeton 2024
 
-import meshtastic.serial_interface #pip install meshtastic or use launch.sh for venv
-import meshtastic.tcp_interface
-import meshtastic.ble_interface
+from meshcore import MeshCore, EventType
 import time
 import asyncio
 import random
@@ -331,116 +329,81 @@ if ble_count > 1:
     logger.critical(f"System: Multiple BLE interfaces detected. Only one BLE interface is allowed. Exiting")
     exit()
 
-# Initialize interfaces
-logger.debug(f"System: Initializing Interfaces")
+# Interface globals — actual connections created in async init_interfaces()
+logger.debug("System: Declaring interface globals (MeshCore async init deferred)")
 interface1 = interface2 = interface3 = interface4 = interface5 = interface6 = interface7 = interface8 = interface9 = None
 retry_int1 = retry_int2 = retry_int3 = retry_int4 = retry_int5 = retry_int6 = retry_int7 = retry_int8 = retry_int9 = False
-myNodeNum1 = myNodeNum2 = myNodeNum3 = myNodeNum4 = myNodeNum5 = myNodeNum6 = myNodeNum7 = myNodeNum8 = myNodeNum9 = 777
+myNodeNum1 = myNodeNum2 = myNodeNum3 = myNodeNum4 = myNodeNum5 = myNodeNum6 = myNodeNum7 = myNodeNum8 = myNodeNum9 = "000000000000"
 max_retry_count1 = max_retry_count2 = max_retry_count3 = max_retry_count4 = max_retry_count5 = max_retry_count6 = max_retry_count7 = max_retry_count8 = max_retry_count9 = interface_retry_count
-for i in range(1, 10):
-    interface_type = globals().get(f'interface{i}_type')
-    if not interface_type or interface_type == 'none' or globals().get(f'interface{i}_enabled') == False:
-        # no valid interface found
-        continue
-    try:
-        if globals().get(f'interface{i}_enabled'):
-            if interface_type == 'serial':
-                globals()[f'interface{i}'] = meshtastic.serial_interface.SerialInterface(globals().get(f'port{i}'))
-            elif interface_type == 'tcp':
-                host = globals().get(f'hostname{i}', '127.0.0.1')
-                port = 4403
+my_node_ids = []
 
-                # Allow host:port format
-                if isinstance(host, str) and ':' in host:
-                    maybe_host, maybe_port = host.rsplit(':', 1)
-                    if maybe_port.isdigit():
-                        host = maybe_host
-                        try:
-                            port = int(maybe_port)
-                        except ValueError:
-                            port = 4403
+# Contact cache: pubkey_prefix (12-char hex) -> {name_long, name_short, pubkey, snr, last_seen}
+_contacts = {}
 
-                globals()[f'interface{i}'] = meshtastic.tcp_interface.TCPInterface(hostname=host, portNumber=port)
-            elif interface_type == 'ble':
-                globals()[f'interface{i}'] = meshtastic.ble_interface.BLEInterface(globals().get(f'mac{i}'))
-            else:
-                logger.critical(f"System: Interface Type: {interface_type} not supported. Validate your config against config.template Exiting")
-                exit()
-    except Exception as e:
-        logger.critical(f"System: abort. Initializing Interface{i} {e}")
+def get_interface(nodeInt=1):
+    """Return the live MeshCore interface object for the given slot."""
+    return globals().get(f'interface{nodeInt}')
+
+def update_contact(pubkey_prefix, name_long="", name_short="", pubkey="", snr=0):
+    """Upsert a contact in the in-memory cache."""
+    existing = _contacts.get(pubkey_prefix, {})
+    _contacts[pubkey_prefix] = {
+        'name_long': name_long or existing.get('name_long') or pubkey_prefix,
+        'name_short': name_short or existing.get('name_short') or pubkey_prefix[:8],
+        'pubkey': pubkey or existing.get('pubkey', ''),
+        'snr': snr,
+        'last_seen': time.time(),
+    }
+
+async def _connect_interface(i):
+    """Connect a single interface slot and return the MeshCore object."""
+    interface_type = globals().get(f'interface{i}_type', '').lower()
+    if interface_type == 'serial':
+        port = globals().get(f'port{i}')
+        return await MeshCore.create_serial(port) if port else await MeshCore.create_serial()
+    elif interface_type == 'tcp':
+        host = globals().get(f'hostname{i}', '127.0.0.1')
+        port = 5000
+        if isinstance(host, str) and ':' in host:
+            maybe_host, maybe_port = host.rsplit(':', 1)
+            if maybe_port.isdigit():
+                host = maybe_host
+                port = int(maybe_port)
+        return await MeshCore.create_tcp(host=host, port=port)
+    elif interface_type == 'ble':
+        return await MeshCore.create_ble(address=globals().get(f'mac{i}'))
+    else:
+        logger.critical(f"System: Interface type '{interface_type}' not supported. Exiting")
         exit()
 
-# Get my node numbers for global use       
-my_node_ids = [globals().get(f'myNodeNum{i}') for i in range(1, 10)]
-
-# Get the node number of the devices, check if the devices are connected meshtastic devices
-for i in range(1, 10):
-    if globals().get(f'interface{i}') and globals().get(f'interface{i}_enabled'):
-        try:
-            globals()[f'myNodeNum{i}'] = globals()[f'interface{i}'].getMyNodeInfo()['num']
-            logger.debug(f"System: Initalized Radio Device{i} Node Number: {globals()[f'myNodeNum{i}']}")
-        except Exception as e:
-            logger.critical(f"System: critical error initializing interface{i} {e}")
-    else:
-        globals()[f'myNodeNum{i}'] = 777
-
-# Fetch channel list from each device
-_channel_cache = None
-
-def build_channel_cache(force_refresh: bool = False):
-    """
-    Build and cache channel_list from interfaces once (or when forced).
-    """
-    global _channel_cache
-    if _channel_cache is not None and not force_refresh:
-        return _channel_cache
-
-    cache = []
+async def init_interfaces():
+    """Connect to all configured radio interfaces via MeshCore (call once from main())."""
+    global my_node_ids
     for i in range(1, 10):
-        if not globals().get(f'interface{i}') or not globals().get(f'interface{i}_enabled'):
+        interface_type = globals().get(f'interface{i}_type', '')
+        if not interface_type or interface_type == 'none' or not globals().get(f'interface{i}_enabled'):
             continue
         try:
-            node = globals()[f'interface{i}'].getNode('^local')
-            # Try to use the node-provided channel/hash table if available
+            mc = await _connect_interface(i)
+            globals()[f'interface{i}'] = mc
+            logger.debug(f"System: Interface{i} connected via {interface_type}")
             try:
-                ch_hash_table_raw = node.get_channels_with_hash()
-                #print(f"System: Device{i} Channel Hash Table: {ch_hash_table_raw}")
+                await mc.commands.get_contacts()
             except Exception:
-                logger.warning(f"System: API version error update API `pip3 install --upgrade meshtastic[cli]`")
-                ch_hash_table_raw = []
-
-            channel_dict = {}
-            # Use the hash table as the source of truth for channels
-            if isinstance(ch_hash_table_raw, list):
-                for entry in ch_hash_table_raw:
-                    channel_name = entry.get("name", "").strip()
-                    channel_number = entry.get("index")
-                    ch_hash = entry.get("hash")
-                    role = entry.get("role", "")
-                    # Always add PRIMARY/SECONDARY channels, even if name is empty
-                    if role in ("PRIMARY", "SECONDARY"):
-                        channel_dict[channel_name if channel_name else f"Channel{channel_number}"] = {
-                            "number": channel_number,
-                            "hash": ch_hash
-                        }
-            elif isinstance(ch_hash_table_raw, dict):
-                for channel_name, ch_hash in ch_hash_table_raw.items():
-                    channel_dict[channel_name] = {"number": None, "hash": ch_hash}
-            # Always add the interface, even if no named channels
-            cache.append({"interface_id": i, "channels": channel_dict})
-            logger.debug(f"System: Fetched Channel List from Device{i} (cached)")
+                pass
         except Exception as e:
-            logger.debug(f"System: Error fetching channel list from Device{i}: {e}")
+            logger.critical(f"System: Error connecting Interface{i}: {e}")
+            exit()
+    my_node_ids = [globals().get(f'myNodeNum{i}') for i in range(1, 10)]
 
-    _channel_cache = cache
-    return _channel_cache
+def build_channel_cache(force_refresh: bool = False):
+    """Stub: MeshCore channel resolution not yet implemented."""
+    return []
 
 def refresh_channel_cache():
-    """Force rebuild of channel cache (call only when channel config changes)."""
     return build_channel_cache(force_refresh=True)
 
 channel_list = build_channel_cache()
-#print(f"System: Channel Cache Built: {channel_list}")
 
 #### FUN-ctions ####
 def resolve_channel_name(channel_number, rxNode=1, interface_obj=None):
@@ -539,224 +502,57 @@ def cleanup_game_trackers(current_time):
         logger.error(f"System: Error cleaning up game trackers: {e}")
 
 def decimal_to_hex(decimal_number):
-    return f"!{decimal_number:08x}"
+    try:
+        return f"!{int(decimal_number):08x}"
+    except (TypeError, ValueError):
+        return str(decimal_number)
 
 def get_name_from_number(number, type='long', nodeInt=1):
-    interface = globals()[f'interface{nodeInt}']
-    name = ""
-    
-    for node in interface.nodes.values():
-        if number == node['num']:
-            if type == 'long':
-                name = node['user']['longName']
-                return name
-            elif type == 'short':
-                name = node['user']['shortName']
-                return name
-        else:
-            name =  str(decimal_to_hex(number))  # If name not found, use the ID as string
-    return name
+    """Look up display name for a pubkey_prefix from the contact cache."""
+    key = str(number)
+    contact = _contacts.get(key)
+    if contact:
+        return contact['name_long'] if type == 'long' else contact['name_short']
+    return key  # show the pubkey prefix if no name known
 
 def get_num_from_short_name(short_name, nodeInt=1):
-    # First, search the specified interface
-    interface = globals()[f'interface{nodeInt}']
-    logger.debug(f"System: Checking Node Number from Short Name: {short_name} on Device: {nodeInt}")
-    for node in interface.nodes.values():
-        if short_name == node['user']['shortName'] or str(short_name).lower() == node['user']['shortName'].lower():
-            return node['num']
-
-    # If not found, search all other enabled interfaces
-    for iface_num in range(1, 10):
-        if iface_num == nodeInt:
-            continue
-        if globals().get(f'interface{iface_num}_enabled'):
-            other_interface = globals().get(f'interface{iface_num}')
-            for node in other_interface.nodes.values():
-                if short_name == node['user']['shortName'] or str(short_name).lower() == node['user']['shortName'].lower():
-                    logger.debug(f"System: Found Device:{iface_num} Node:{node['user']['shortName']}")
-                    return node['num']
-
-    # !hex node IDs
-    if str(short_name).startswith("!"):
-        try:
-            return int(short_name[1:], 16)
-        except Exception:
-            pass
-
-    return 0
+    """Return the pubkey_prefix matching a short name, or the input unchanged."""
+    short_lower = str(short_name).lower()
+    for prefix, info in _contacts.items():
+        if info.get('name_short', '').lower() == short_lower:
+            return prefix
+    return str(short_name)
     
 def get_node_list(nodeInt=1):
-    interface = globals()[f'interface{nodeInt}']
-    # Get a list of nodes on the device
-    node_list = ""
-    node_list1 = []
-    node_list2 = []
-    short_node_list = []
-    last_heard = 0
-    if interface.nodes:
-        for node in interface.nodes.values():
-            # ignore own
-            if all(node['num'] != globals().get(f'myNodeNum{i}') for i in range(1, 10)):
-                node_name = get_name_from_number(node['num'], 'short', nodeInt)
-                snr = node.get('snr', 0)
-
-                # issue where lastHeard is not always present
-                last_heard = node.get('lastHeard', 0)
-                
-                # make a list of nodes with last heard time and SNR
-                item = (node_name, last_heard, snr)
-                node_list1.append(item)
-    else:
-        logger.warning(f"System: No nodes found")
+    """Return a formatted string of recently-heard contacts from the cache."""
+    if not _contacts:
+        logger.warning("System: No contacts in cache yet")
         return ERROR_FETCHING_DATA
-    
-    try:
-        #print (f"Node List: {node_list1[:5]}\n")
-        node_list1.sort(key=lambda x: x[1] if x[1] is not None else 0, reverse=True)
-        #print (f"Node List: {node_list1[:5]}\n")
-        if multiple_interface:
-            logger.debug(f"System: FIX ME line 327 Multiple Interface Node List")
-            node_list2.sort(key=lambda x: x[1] if x[1] is not None else 0, reverse=True)
-    except Exception as e:
-        logger.error(f"System: Error sorting node list: {e}")
-        logger.debug(f"Node List1: {node_list1[:5]}\n")
-        if multiple_interface:
-            logger.debug(f"FIX ME MULTI INTERFACE Node List2: {node_list2[:5]}\n")
-        node_list = ERROR_FETCHING_DATA
-
-    try:
-        # make a nice list for the user
-        for x in node_list1[:SITREP_NODE_COUNT]:
-            short_node_list.append(f"{x[0]} SNR:{x[2]}")
-        for x in node_list2[:SITREP_NODE_COUNT]:
-            short_node_list.append(f"{x[0]} SNR:{x[2]}")
-
-        for x in short_node_list:
-            if x != "" or x != '\n':
-                node_list += x + "\n"
-    except Exception as e:
-        logger.error(f"System: Error creating node list: {e}")
-        node_list = ERROR_FETCHING_DATA
-    
+    sorted_contacts = sorted(_contacts.items(), key=lambda x: x[1].get('last_seen', 0), reverse=True)
+    node_list = ""
+    for prefix, info in sorted_contacts[:SITREP_NODE_COUNT]:
+        snr = info.get('snr', 0)
+        node_list += f"{info.get('name_short', prefix)} SNR:{snr}\n"
     return node_list
 
 def get_node_location(nodeID, nodeInt=1, channel=0, round_digits=2):
-    """
-    Returns [latitude, longitude] for a node.
-    - Always returns a fuzzed (rounded) config location as fallback.
-    - returns their actual position if available, else fuzzed config location.
-    """
-    interface = globals()[f'interface{nodeInt}']
-
-    fuzzed_position = [round(latitudeValue, round_digits), round(longitudeValue, round_digits)]
-    config_position = [latitudeValue, longitudeValue]
-
-    # Try to find an exact location for the requested node
-    if interface.nodes:
-        for node in interface.nodes.values():
-            if nodeID == node['num']:
-                pos = node.get('position')
-                if (
-                    pos and isinstance(pos, dict)
-                    and pos.get('latitude') is not None
-                    and pos.get('longitude') is not None
-                ):
-                    try:
-                        # Got a valid position
-                        latitude = pos['latitude']
-                        longitude = pos['longitude']
-                        if fuzzItAll:
-                            latitude = round(latitude, round_digits)
-                            longitude = round(longitude, round_digits)
-                            logger.debug(f"System: Fuzzed location data for {nodeID} is {latitude}, {longitude}")
-                        logger.debug(f"System: Location data for {nodeID} is {latitude}, {longitude}")
-                        return [latitude, longitude]
-                    except Exception as e:
-                        logger.warning(f"System: Error processing position for node {nodeID}: {e}")
-
+    """Return [lat, lon]; MeshCore contact positions not yet tracked — returns config location."""
     if fuzz_config_location:
-        # Return fuzzed config location if no valid position found
-        return fuzzed_position
-    else:
-        return config_position
-    
-async def get_closest_nodes(nodeInt=1,returnCount=3, channel=publicChannel):
-        interface = globals()[f'interface{nodeInt}']
-        node_list = []
+        return [round(latitudeValue, round_digits), round(longitudeValue, round_digits)]
+    return [latitudeValue, longitudeValue]
 
-        if interface.nodes:
-            for node in interface.nodes.values():
-                if 'position' in node:
-                    try:
-                        nodeID = node['num']
-                        latitude = node['position']['latitude']
-                        longitude = node['position']['longitude']
+async def get_closest_nodes(nodeInt=1, returnCount=3, channel=publicChannel):
+    """Stub: per-node location not available via MeshCore contact cache yet."""
+    logger.warning("System: get_closest_nodes not implemented for MeshCore yet")
+    return ERROR_FETCHING_DATA
 
-                        #lastheard time in unix time
-                        lastheard = node.get('lastHeard', 0)
-                        #if last heard is over 24 hours ago, ignore the node
-                        if lastheard < (time.time() - 86400):
-                            continue
-
-                        # Calculate distance to node from config.ini location
-                        distance = round(geopy.distance.geodesic((latitudeValue, longitudeValue), (latitude, longitude)).m, 2)
-                        
-                        if (distance < sentry_radius):
-                            if (nodeID not in my_node_ids) and str(nodeID) not in sentryIgnoreList:
-                                node_list.append({'id': nodeID, 'latitude': latitude, 'longitude': longitude, 'distance': distance})
-                                
-                    except Exception as e:
-                        pass
-                else:
-                    # request location data currently blocking needs to be async
-                    reqLocationEnabled = False
-                    if reqLocationEnabled:
-                        try:
-                            logger.debug(f"System: Requesting location data for {node['id']}, lastHeard: {node.get('lastHeard', 'N/A')}")
-                            # if not a interface node
-                            if node['num'] in my_node_ids:
-                                ignore = True
-                            else:
-                                # one idea is to send a ping to the node to request location data for if or when, ask again later
-                                interface.sendPosition(destinationId=node['id'], wantResponse=False, channelIndex=channel)
-                                # wayyy too fast async wait
-                                
-                                # send a traceroute request
-                                interface.sendTraceRoute(destinationId=node['id'], channelIndex=channel, wantResponse=False)
-                        except Exception as e:
-                            logger.error(f"System: Error requesting location data for {node['id']}. Error: {e}")
-            # sort by distance closest
-            #node_list.sort(key=lambda x: (x['latitude']-latitudeValue)**2 + (x['longitude']-longitudeValue)**2)
-            node_list.sort(key=lambda x: x['distance'])
-            # return the first 3 closest nodes by default
-            return node_list[:returnCount]
-        else:
-            logger.warning(f"System: No nodes found in closest_nodes on interface {nodeInt}")
-            return ERROR_FETCHING_DATA
-    
 def handleFavoriteNode(nodeInt=1, nodeID=0, aor=False):
-    # Add or remove a favorite node for the given interface. aor: True to add, False to remove.
-    interface = globals()[f'interface{nodeInt}']
-    myNodeNumber = globals().get(f'myNodeNum{nodeInt}')
-    try:
-        if aor:
-            result = interface.getNode(myNodeNumber).setFavorite(nodeID)
-            logger.info(f"System: Added {nodeID} to favorites for device {nodeInt}")
-        else:
-            result = interface.getNode(myNodeNumber).removeFavorite(nodeID)
-            logger.info(f"System: Removed {nodeID} from favorites for device {nodeInt}")
-        return result
-    except Exception as e:
-        logger.error(f"System: Error handling favorite node {nodeID} on device {nodeInt}: {e}")
-        return None
-    
+    logger.warning("System: handleFavoriteNode not implemented for MeshCore yet")
+    return None
+
 def getFavoritNodes(nodeInt=1):
-    interface = globals()[f'interface{nodeInt}']
-    myNodeNumber = globals().get(f'myNodeNum{nodeInt}')
-    favList = []
-    for node in interface.getNode(myNodeNumber).favorites:
-        favList.append(node)
-    return favList
+    logger.warning("System: getFavoritNodes not implemented for MeshCore yet")
+    return []
 
 def handleSentinelIgnore(nodeInt=1, nodeID=0, aor=False):
     #aor is add or remove if True add, if False remove
@@ -852,130 +648,45 @@ def messageChunker(message):
     except Exception as e:
         logger.warning(f"System: Exception during message chunking: {e} (message length: {len(message)})")
         
-def send_message(message, ch, nodeid=0, nodeInt=1, bypassChuncking=False, reply_id=None):
-    # Send a message to a channel or DM
-    interface = globals()[f'interface{nodeInt}']
-    # Check if the message is empty
-    if message == "" or message is None or len(message) == 0:
+async def send_message(message, ch, nodeid=0, nodeInt=1, bypassChuncking=False, reply_id=None):
+    """Send a DM or channel message via MeshCore."""
+    interface = globals().get(f'interface{nodeInt}')
+    if not interface:
+        logger.warning(f"System: Interface{nodeInt} not connected, cannot send message")
+        return False
+    if not message:
         return False
 
     try:
-        def _send_with_reply(**kwargs):
-            # For threaded replies, send as DATA payload to match Meshtastic inline-reply behavior. no API call today.
-            if reply_id is not None:
-                text_payload = kwargs.pop('text', '')
-                if isinstance(text_payload, str):
-                    raw_payload = text_payload.encode('utf-8')
-                else:
-                    raw_payload = text_payload
-
-                data_kwargs = {
-                    # 1 == TEXT_MESSAGE_APP, required so clients render payload as chat text.
-                    'portNum': 1,
-                    'channelIndex': kwargs.get('channelIndex', ch),
-                    'wantAck': kwargs.get('wantAck', wantAck),
-                }
-                if kwargs.get('destinationId'):
-                    data_kwargs['destinationId'] = kwargs.get('destinationId')
-                # send the data payload with the replyId for threading
-                return interface.sendData(raw_payload, replyId=reply_id, **data_kwargs)
-            # Otherwise, send as normal text message
-            return interface.sendText(**kwargs)
-
-        # Force chunking and log if message exceeds maxBuffer
-        if len(message.encode('utf-8')) > maxBuffer:
-            logger.debug(f"System: Message length {len(message.encode('utf-8'))} exceeds maxBuffer{maxBuffer}, forcing chunking.")
-            message_list = messageChunker(message)
-        elif not bypassChuncking:
-            # Split the message into chunks if it exceeds the MESSAGE_CHUNK_SIZE
+        if len(message.encode('utf-8')) > maxBuffer or not bypassChuncking:
             message_list = messageChunker(message)
         else:
             message_list = [message]
 
-        if isinstance(message_list, list):
-            # Send the message to the channel or DM
-            total_length = sum(len(chunk) for chunk in message_list)
-            num_chunks = len(message_list)
-            for m in message_list:
-                chunkOf = f"{message_list.index(m)+1}/{num_chunks}"
-                if nodeid == 0:
-                    # Send to channel
-                    if wantAck:
-                        logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + f"req.ACK " + f"Chunker{chunkOf} SendingChannel: " + CustomFormatter.white + m.replace('\n', ' '))
-                        _send_with_reply(text=m, channelIndex=ch, wantAck=True)
-                    else:
-                        logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + f"Chunker{chunkOf} SendingChannel: " + CustomFormatter.white + m.replace('\n', ' '))
-                        _send_with_reply(text=m, channelIndex=ch)
-                else:
-                    # Send to DM
-                    if wantAck:
-                        logger.info(f"Device:{nodeInt} " + CustomFormatter.red + f"req.ACK " + f"Chunker{chunkOf} Sending DM: " + CustomFormatter.white + m.replace('\n', ' ') + CustomFormatter.purple +\
-                                 " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
-                        _send_with_reply(text=m, channelIndex=ch, destinationId=nodeid, wantAck=True)
-                    else:
-                        logger.info(f"Device:{nodeInt} " + CustomFormatter.red + f"Chunker{chunkOf} Sending DM: " + CustomFormatter.white + m.replace('\n', ' ') + CustomFormatter.purple +\
-                                    " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
-                        _send_with_reply(text=m, channelIndex=ch, destinationId=nodeid)
+        if not isinstance(message_list, list):
+            message_list = [message]
 
-                # Throttle the message sending to prevent spamming the device
-                if (message_list.index(m)+1) % 4 == 0:
-                    time.sleep(responseDelay + 1)
-                    if (message_list.index(m)+1) % 5 == 0:
-                        logger.warning(f"System: throttling rate Interface{nodeInt} on {chunkOf}")
-
-                # wait an amount of time between sending each split message
-                time.sleep(splitDelay)
-        else: # message is less than MESSAGE_CHUNK_SIZE characters
-            if nodeid == 0:
-                # Send to channel
-                if wantAck:
-                    logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + "req.ACK " + "SendingChannel: " + CustomFormatter.white + message.replace('\n', ' '))
-                    _send_with_reply(text=message, channelIndex=ch, wantAck=True)
-                else:
-                    logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + "SendingChannel: " + CustomFormatter.white + message.replace('\n', ' '))
-                    _send_with_reply(text=message, channelIndex=ch)
+        num_chunks = len(message_list)
+        for idx, m in enumerate(message_list):
+            chunkOf = f"{idx+1}/{num_chunks}"
+            if nodeid == 0 or nodeid == "0":
+                logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + f"Chunker{chunkOf} SendingChannel: " + CustomFormatter.white + m.replace('\n', ' '))
+                await interface.commands.send_chan_msg(ch, m)
             else:
-                # Send to DM
-                if wantAck:
-                    logger.info(f"Device:{nodeInt} " + CustomFormatter.red + "req.ACK " + "Sending DM: " + CustomFormatter.white + message.replace('\n', ' ') + CustomFormatter.purple +\
-                                 " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
-                    _send_with_reply(text=message, channelIndex=ch, destinationId=nodeid, wantAck=True)
-                else:
-                    logger.info(f"Device:{nodeInt} " + CustomFormatter.red + "Sending DM: " + CustomFormatter.white + message.replace('\n', ' ') + CustomFormatter.purple +\
-                                " To: " + CustomFormatter.white + f"{get_name_from_number(nodeid, 'long', nodeInt)}")
-                    _send_with_reply(text=message, channelIndex=ch, destinationId=nodeid)
-            # Throttle the message sending to prevent spamming the device
-            time.sleep(responseDelay)
+                dst = str(nodeid)
+                logger.info(f"Device:{nodeInt} " + CustomFormatter.red + f"Chunker{chunkOf} Sending DM: " + CustomFormatter.white + m.replace('\n', ' ') + CustomFormatter.purple +
+                            " To: " + CustomFormatter.white + f"{get_name_from_number(dst, 'long', nodeInt)}")
+                await interface.commands.send_msg(dst, m)
+            await asyncio.sleep(splitDelay)
         return True
     except Exception as e:
         logger.error(f"System: Exception during send_message: {e} (message length: {len(message)})")
         return False
 
-def send_raw_bytes(nodeid, raw_bytes, nodeInt=1, channel=0, portnum=256, want_ack=True, reply_id=None):
-    # Send raw bytes to a node using the Meshtastic interface.
-    interface = globals()[f'interface{nodeInt}']
-    try:
-        send_kwargs = {
-            'destinationId': nodeid,
-            'portNum': portnum,
-            'channelIndex': channel,
-            'wantAck': want_ack,
-        }
-        if reply_id is not None:
-            try:
-                interface.sendData(raw_bytes, replyId=reply_id, **send_kwargs)
-            except TypeError:
-                logger.debug("System: replyId/replyID unsupported for sendData; sending without threaded reply")
-                interface.sendData(raw_bytes, **send_kwargs)
-        else:
-            interface.sendData(raw_bytes, **send_kwargs)
-        # Throttle the message sending to prevent spamming the device
-        logger.debug(f"System: Sent raw bytes to {nodeid} on portnum {portnum} via Device{nodeInt}")
-        time.sleep(responseDelay)
-        return True
-    except Exception as e:
-        logger.error(f"System: Error sending raw bytes to {nodeid} via Device{nodeInt}: {e} bytes: {raw_bytes}")
-        return False
+async def send_raw_bytes(nodeid, raw_bytes, nodeInt=1, channel=0, portnum=256, want_ack=True, reply_id=None):
+    """Stub: raw-byte sending not yet implemented for MeshCore."""
+    logger.warning(f"System: send_raw_bytes not implemented for MeshCore yet")
+    return False
 
 def decode_raw_bytes(raw_bytes):
     # Decode raw bytes received from a Meshtastic device.
@@ -1254,7 +965,7 @@ def handle_bbsban(message, message_from_id, isDM):
 
     return msg
 
-def handleMultiPing(nodeID=0, deviceID=1):
+async def handleMultiPing(nodeID=0, deviceID=1):
     global multiPingList
     if len(multiPingList) > 1:
         mPlCpy = multiPingList.copy()
@@ -1293,7 +1004,7 @@ def handleMultiPing(nodeID=0, deviceID=1):
                         count -= 1
 
                 # send the DM
-                send_message(f"🔂{count} {type}", channel_number, message_id_from, deviceID, bypassChuncking=True)
+                await send_message(f"🔂{count} {type}", channel_number, message_id_from, deviceID, bypassChuncking=True)
                 if count < 2:
                     # remove the item from the list
                     for j in range(len(multiPingList)):
@@ -1320,7 +1031,7 @@ def should_send_alert(alert_type, new_message, min_interval=1):
         return True
     return False
 
-def handleAlertBroadcast(deviceID=1):
+async def handleAlertBroadcast(deviceID=1):
     try:
         alertUk = alertDe = alertFema = wxAlert = volcanoAlert = overdueAlerts = NO_ALERTS
         alertWx = False
@@ -1330,8 +1041,8 @@ def handleAlertBroadcast(deviceID=1):
         if checklist_enabled:
             overdueAlerts = format_overdue_alert()
             if overdueAlerts:
-                if should_send_alert("overdue", overdueAlerts, min_interval=300): # 5 minutes interval for overdue alerts
-                    send_message(overdueAlerts, emergency_responder_alert_channel, 0, emergency_responder_alert_interface)
+                if should_send_alert("overdue", overdueAlerts, min_interval=300):
+                    await send_message(overdueAlerts, emergency_responder_alert_channel, 0, emergency_responder_alert_interface)
 
         # Only allow API call every alert_duration minutes at xx:00, xx:20, xx:40
         if not (clock.minute % alert_duration == 0 and clock.second <= 17):
@@ -1363,14 +1074,14 @@ def handleAlertBroadcast(deviceID=1):
             if enabled and alert_msg and NO_ALERTS not in alert_msg and ERROR_FETCHING_DATA not in alert_msg:
                 if should_send_alert(alert_type, alert_msg):
                     logger.debug(f"System: Sending {alert_type} alert to emergency responder channel {emergency_responder_alert_channel}")
-                    send_message(alert_msg, emergency_responder_alert_channel, 0, emergency_responder_alert_interface)
+                    await send_message(alert_msg, emergency_responder_alert_channel, 0, emergency_responder_alert_interface)
                 if eAlertBroadcastChannel:
                     for ch in eAlertBroadcastChannel:
                         ch = ch.strip()
                         if ch:
                             logger.debug(f"System: Sending {alert_type} alert to aux channel {ch}")
-                            time.sleep(splitDelay)
-                            send_message(alert_msg, int(ch), 0, emergency_responder_alert_interface)
+                            await asyncio.sleep(splitDelay)
+                            await send_message(alert_msg, int(ch), 0, emergency_responder_alert_interface)
     except Exception as e:
         logger.error(f"System: Error in handleAlertBroadcast: {e}")
     return False
@@ -1393,125 +1104,37 @@ def initialize_telemetryData():
 initialize_telemetryData()
 
 def getNodeFirmware(nodeID=0, nodeInt=1):
-    interface = globals()[f'interface{nodeInt}']
-    # get the firmware version of the node
-    # this is a workaround because .localNode.getMetadata spits out a lot of debug info which cant be suppressed
-    # Create a StringIO object to capture the 
-    output_capture = io.StringIO()
-    with contextlib.redirect_stdout(output_capture), contextlib.redirect_stderr(output_capture):
-        interface.localNode.getMetadata()
-    console_output = output_capture.getvalue()
-    if "firmware_version" in console_output:
-        fwVer = console_output.split("firmware_version: ")[1].split("\n")[0]
-        return fwVer
-    return -1
+    """MeshCore firmware version not directly queryable — return placeholder."""
+    return "MeshCore"
 
 def compileFavoriteList(getInterfaceIDs=True):
-    # build a list of favorite nodes to add to the device
+    """Build a list of known pubkey prefixes for configured interfaces."""
     fav_list = []
-
     if getInterfaceIDs:
-        logger.debug(f"System:compileFavoriteList Collecting Nodes for use on roof client_base only")
-        # get the node IDs for each interface
         for i in range(1, 10):
-            if globals().get(f'interface{i}') and globals().get(f'interface{i}_enabled'):
-                myNodeNum = globals().get(f'myNodeNum{i}', 0)
-                if myNodeNum != 0:
-                    object = {'nodeID': myNodeNum, 'deviceID': i}
-                    fav_list.append(object)
-                    logger.debug(f"System:compileFavoriteList Added NodeID {myNodeNum} favorite list")
-
-    if not getInterfaceIDs:
-        logger.debug(f"System:compileFavoriteList Compiling Favorite Node List for use on bot to save DM keys only")
-        if (bbs_admin_list != [0] or favoriteNodeList != ['']) or bbs_link_whitelist != [0]:
-            logger.debug(f"System: Collecting Favorite Nodes to add to device(s)")
-            # loop through each interface and add the favorite nodes
-            for i in range(1, 10):
-                if globals().get(f'interface{i}') and globals().get(f'interface{i}_enabled'):
-                    for fav in bbs_admin_list + favoriteNodeList + bbs_link_whitelist:
-                        if fav != 0 and fav != '' and fav is not None:
-                            object = {'nodeID': fav, 'deviceID': i}
-                            # check object not already in the list
-                            if object not in fav_list:
-                                fav_list.append(object)
-                                logger.debug(f"System:compileFavoriteList Favorite Node {fav}")
+            myNodeNum = globals().get(f'myNodeNum{i}', "000000000000")
+            if globals().get(f'interface{i}') and myNodeNum != "000000000000":
+                fav_list.append({'nodeID': myNodeNum, 'deviceID': i})
     return fav_list
 
 def displayNodeTelemetry(nodeID=0, rxNode=0, userRequested=False):
-    interface = globals()[f'interface{rxNode}']
-    myNodeNum = globals().get(f'myNodeNum{rxNode}')
+    """Return basic telemetry from localTelemetryData (per-radio metrics from MeshCore not yet wired)."""
     global localTelemetryData
-  
-    # throttle the telemetry requests to prevent spamming the device
     if 1 <= rxNode <= 9:
         if time.time() - localTelemetryData[0][f'interface{rxNode}'] < 600 and not userRequested:
             return -1
         localTelemetryData[0][f'interface{rxNode}'] = time.time()
 
-    # some telemetry data is not available in python-meshtastic?
-    # bring in values from the last telemetry dump for the node
     numPacketsTx = localTelemetryData[rxNode].get('numPacketsTx', 0)
     numPacketsRx = localTelemetryData[rxNode].get('numPacketsRx', 0)
     numPacketsTxErr = localTelemetryData[rxNode].get('numPacketsTxErr', 0)
     numPacketsRxErr = localTelemetryData[rxNode].get('numPacketsRxErr', 0)
-    numTotalNodes = localTelemetryData[rxNode].get('numTotalNodes', 0)
     totalOnlineNodes = localTelemetryData[rxNode].get('numOnlineNodes', 0)
-    numRXDupes = localTelemetryData[rxNode].get('numRXDupes', 0)
-    numTxRelays = localTelemetryData[rxNode].get('numTxRelays', 0)
-    heapFreeBytes = localTelemetryData[rxNode].get('heapFreeBytes', 0)
-    heapTotalBytes = localTelemetryData[rxNode].get('heapTotalBytes', 0)
-    # get the telemetry data for a node
-    chutil = round(interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("deviceMetrics", {}).get("channelUtilization", 0), 1)
-    airUtilTx = round(interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("deviceMetrics", {}).get("airUtilTx", 0), 1)
-    uptimeSeconds = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("deviceMetrics", {}).get("uptimeSeconds", 0)
-    batteryLevel = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("deviceMetrics", {}).get("batteryLevel", 0)
-    voltage = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("deviceMetrics", {}).get("voltage", 0)
-    #numPacketsRx = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("localStats", {}).get("numPacketsRx", 0)
-    #numPacketsTx = interface.nodes.get(decimal_to_hex(myNodeNum), {}).get("localStats", {}).get("numPacketsTx", 0)
-    numTotalNodes = len(interface.nodes) 
-    
+    numTotalNodes = len(_contacts)
+
     dataResponse = f"Telemetry:{rxNode}"
-
-    # packet info telemetry
     dataResponse += f" numPacketsRx:{numPacketsRx} numPacketsRxErr:{numPacketsRxErr} numPacketsTx:{numPacketsTx} numPacketsTxErr:{numPacketsTxErr}"
-
-    # Channel utilization and airUtilTx
-    dataResponse += " ChUtil%:" + str(round(chutil, 2)) + " AirTx%:" + str(round(airUtilTx, 2))
-
-    if chutil > 40:
-        logger.warning(f"System: High Channel Utilization {chutil}% on Device: {rxNode}")
-
-    if airUtilTx > 25:
-        logger.warning(f"System: High Air Utilization {airUtilTx}% on Device: {rxNode}")
-
-    # Number of nodes
-    dataResponse += " totalNodes:" + str(numTotalNodes) + " Online:" + str(totalOnlineNodes)
-
-    # Uptime
-    uptimeSeconds = getPrettyTime(uptimeSeconds)
-    dataResponse += " Uptime:" + str(uptimeSeconds)
-
-    # add battery info to the response
-    emji = "🔌" if batteryLevel == 101 else "🪫" if batteryLevel < 10 else "🔋"
-    dataResponse += f" Volt:{round(voltage, 1)}"
-
-    if batteryLevel < 25:
-        logger.warning(f"System: Low Battery Level: {batteryLevel}{emji} on Device: {rxNode}")
-        send_message(f"Low Battery Level: {batteryLevel}{emji} on Device: {rxNode}", {secure_channel}, 0, {secure_interface})
-    elif batteryLevel < 10:
-        logger.critical(f"System: Critical Battery Level: {batteryLevel}{emji} on Device: {rxNode}")
-
-    # if numRXDupes,numTxRelays,heapFreeBytes,heapTotalBytes are available loge them
-    # if numRXDupes != 0:
-    #     dataResponse += f" RXDupes:{numRXDupes}"
-    #     logger.debug(f"System: Device {rxNode} RX Dupes:{numRXDupes}")
-    # if numTxRelays != 0:
-    #     dataResponse += f" TxRelays:{numTxRelays}"
-    #     logger.debug(f"System: Device {rxNode} TX Relays:{numTxRelays}")
-    # if heapFreeBytes != 0 and heapTotalBytes != 0:
-    #     logger.debug(f"System: Device {rxNode} Heap Memory Free:{heapFreeBytes} Total:{heapTotalBytes}")
-        #dataResponse += f" Heap:{heapFreeBytes}/{heapTotalBytes}"
-
+    dataResponse += f" totalNodes:{numTotalNodes} Online:{totalOnlineNodes}"
     return dataResponse
 
 positionMetadata = {}
@@ -2189,12 +1812,12 @@ async def handleSignalWatcher():
                 if type(sigWatchBroadcastCh) is list:
                     for ch in sigWatchBroadcastCh:
                         if antiSpam and ch != publicChannel:
-                            send_message(msg, int(ch), 0, sigWatchBroadcastInterface)
+                            await send_message(msg, int(ch), 0, sigWatchBroadcastInterface)
                         else:
                             logger.warning(f"System: antiSpam prevented Alert from Hamlib {msg}")
                 else:
                     if antiSpam and sigWatchBroadcastCh != publicChannel:
-                        send_message(msg, int(sigWatchBroadcastCh), 0, sigWatchBroadcastInterface)
+                        await send_message(msg, int(sigWatchBroadcastCh), 0, sigWatchBroadcastInterface)
                     else:
                         logger.warning(f"System: antiSpam prevented Alert from Hamlib {msg}")
 
@@ -2216,20 +1839,20 @@ async def handleFileWatcher():
                 if type(file_monitor_broadcastCh) is list:
                     for ch in file_monitor_broadcastCh:
                         if antiSpam and int(ch) != publicChannel:
-                            send_message(msg, int(ch), 0, 1)
+                            await send_message(msg, int(ch), 0, 1)
                             if multiple_interface:
                                 for i in range(2, 10):
                                     if globals().get(f'interface{i}_enabled'):
-                                        send_message(msg, int(ch), 0, i)
+                                        await send_message(msg, int(ch), 0, i)
                         else:
                             logger.warning(f"System: antiSpam prevented Alert from FileWatcher")
                 else:
                     if antiSpam and file_monitor_broadcastCh != publicChannel:
-                        send_message(msg, int(file_monitor_broadcastCh), 0, 1)
+                        await send_message(msg, int(file_monitor_broadcastCh), 0, 1)
                         if multiple_interface:
                             for i in range(2, 10):
                                 if globals().get(f'interface{i}_enabled'):
-                                    send_message(msg, int(file_monitor_broadcastCh), 0, i)
+                                    await send_message(msg, int(file_monitor_broadcastCh), 0, i)
                     else:
                         logger.warning(f"System: antiSpam prevented Alert from FileWatcher")
 
@@ -2253,12 +1876,12 @@ async def handleWsjtxWatcher():
             if type(sigWatchBroadcastCh) is list:
                 for ch in sigWatchBroadcastCh:
                     if antiSpam and int(ch) != publicChannel:
-                        send_message(msg, int(ch), 0, sigWatchBroadcastInterface)
+                        await send_message(msg, int(ch), 0, sigWatchBroadcastInterface)
                     else:
                         logger.warning(f"System: antiSpam prevented Alert from WSJT-X")
             else:
                 if antiSpam and sigWatchBroadcastCh != publicChannel:
-                    send_message(msg, int(sigWatchBroadcastCh), 0, sigWatchBroadcastInterface)
+                    await send_message(msg, int(sigWatchBroadcastCh), 0, sigWatchBroadcastInterface)
                 else:
                     logger.warning(f"System: antiSpam prevented Alert from WSJT-X")
         
@@ -2281,12 +1904,12 @@ async def handleJs8callWatcher():
             if type(sigWatchBroadcastCh) is list:
                 for ch in sigWatchBroadcastCh:
                     if antiSpam and int(ch) != publicChannel:
-                        send_message(msg, int(ch), 0, sigWatchBroadcastInterface)
+                        await send_message(msg, int(ch), 0, sigWatchBroadcastInterface)
                     else:
                         logger.warning(f"System: antiSpam prevented Alert from JS8Call")
             else:
                 if antiSpam and sigWatchBroadcastCh != publicChannel:
-                    send_message(msg, int(sigWatchBroadcastCh), 0, sigWatchBroadcastInterface)
+                    await send_message(msg, int(sigWatchBroadcastCh), 0, sigWatchBroadcastInterface)
                 else:
                     logger.warning(f"System: antiSpam prevented Alert from JS8Call")
         
@@ -2295,59 +1918,28 @@ async def handleJs8callWatcher():
 async def retry_interface(nodeID):
     global retry_int1, retry_int2, retry_int3, retry_int4, retry_int5, retry_int6, retry_int7, retry_int8, retry_int9
     global max_retry_count1, max_retry_count2, max_retry_count3, max_retry_count4, max_retry_count5, max_retry_count6, max_retry_count7, max_retry_count8, max_retry_count9
-    interface = globals()[f'interface{nodeID}']
-    retry_int = globals()[f'retry_int{nodeID}']
 
     if dont_retry_disconnect:
         logger.critical(f"System: dont_retry_disconnect is set, not retrying interface{nodeID}")
         exit_handler()
 
-    if interface is not None:
-        globals()[f'retry_int{nodeID}'] = True
-        globals()[f'max_retry_count{nodeID}'] -= 1
-        logger.debug(f"System: Retrying interface{nodeID} {globals()[f'max_retry_count{nodeID}']} attempts left")
-        try:
-            interface.close()
-            logger.debug(f"System: Retrying interface{nodeID} in 15 seconds")
-        except Exception as e:
-            logger.error(f"System: closing interface{nodeID}: {e}")
-
+    globals()[f'max_retry_count{nodeID}'] -= 1
     if globals()[f'max_retry_count{nodeID}'] == 0:
         logger.critical(f"System: Max retry count reached for interface{nodeID}")
         exit_handler()
 
+    logger.debug(f"System: Retrying Interface{nodeID} in 15 seconds, {globals()[f'max_retry_count{nodeID}']} attempts left")
+    globals()[f'interface{nodeID}'] = None
     await asyncio.sleep(15)
 
     try:
-        if retry_int:
-            interface = None
-            globals()[f'interface{nodeID}'] = None
-            interface_type = globals()[f'interface{nodeID}_type']
-            if interface_type == 'serial':
-                logger.debug(f"System: Retrying Interface{nodeID} Serial on port: {globals().get(f'port{nodeID}')}")
-                globals()[f'interface{nodeID}'] = meshtastic.serial_interface.SerialInterface(globals().get(f'port{nodeID}'))
-            elif interface_type == 'tcp':
-                host = globals().get(f'hostname{nodeID}', '127.0.0.1')
-                port = 4403
-                if isinstance(host, str) and ':' in host:
-                    maybe_host, maybe_port = host.rsplit(':', 1)
-                    if maybe_port.isdigit():
-                        host = maybe_host
-                        try:
-                            port = int(maybe_port)
-                        except ValueError:
-                            port = 4403
-                logger.debug(f"System: Retrying Interface{nodeID} TCP on hostname: {host}:{port}")
-                globals()[f'interface{nodeID}'] = meshtastic.tcp_interface.TCPInterface(hostname=host, portNumber=port)
-            elif interface_type == 'ble':
-                logger.debug(f"System: Retrying Interface{nodeID} BLE on mac: {globals().get(f'mac{nodeID}')}")
-                globals()[f'interface{nodeID}'] = meshtastic.ble_interface.BLEInterface(globals().get(f'mac{nodeID}'))
-            logger.debug(f"System: Interface{nodeID} Opened!")
-            # reset the retry_int and retry_count
-            globals()[f'max_retry_count{nodeID}'] = interface_retry_count
-            globals()[f'retry_int{nodeID}'] = False
+        mc = await _connect_interface(nodeID)
+        globals()[f'interface{nodeID}'] = mc
+        globals()[f'max_retry_count{nodeID}'] = interface_retry_count
+        globals()[f'retry_int{nodeID}'] = False
+        logger.debug(f"System: Interface{nodeID} reconnected!")
     except Exception as e:
-        logger.error(f"System: Error Opening interface{nodeID} on: {e}")
+        logger.error(f"System: Error reconnecting interface{nodeID}: {e}")
 
 handleSentinel_spotted = []
 handleSentinel_loop = 0
@@ -2389,7 +1981,7 @@ async def handleSentinel(deviceID):
                     resolution = metadata.get('precisionBits')
             # Send message alert
             logger.warning(f"System: {detectedNearby} on Interface{deviceID} Accuracy is {resolution}bits")
-            send_message(f"Sentry{deviceID}: {detectedNearby}", secure_channel, 0, secure_interface)
+            await send_message(f"Sentry{deviceID}: {detectedNearby}", secure_channel, 0, secure_interface)
             
             # Send email alerts
             if enableSMTP and email_sentry_alerts:
@@ -2421,7 +2013,7 @@ async def process_vox_queue():
             message = item
             for channel in sigWatchBroadcastCh:
                 if antiSpam and int(channel) != publicChannel:
-                    send_message(message, int(channel), 0, sigWatchBroadcastInterface)
+                    await send_message(message, int(channel), 0, sigWatchBroadcastInterface)
 
 async def handleTTS():
     from modules.radio import generate_and_play_tts, available_voices
@@ -2466,25 +2058,18 @@ async def watchdog():
             retry_int = globals().get(f'retry_int{i}')
             int_enabled = globals().get(f'interface{i}_enabled')
             if interface is not None and not retry_int and int_enabled:
-                try:
-                    firmware = getNodeFirmware(0, i)
-                except Exception as e:
-                    logger.error(f"System: communicating with interface{i}, trying to reconnect: {e}")
-                    globals()[f'retry_int{i}'] = True
+                if sentry_enabled:
+                    await handleSentinel(i)
 
-                if not retry_int and int_enabled:
-                    if sentry_enabled:
-                        await handleSentinel(i)
+                await handleMultiPing(0, i)
 
-                    handleMultiPing(0, i)
+                if usAlerts or checklist_enabled or enableDEalerts:
+                    await handleAlertBroadcast(i)
 
-                    if usAlerts or checklist_enabled or enableDEalerts:
-                        handleAlertBroadcast(i)
-
-                    intData = displayNodeTelemetry(0, i)
-                    if intData != -1 and localTelemetryData[0][f'lastAlert{i}'] != intData:
-                        logger.debug(intData + f" Firmware:{firmware}")
-                        localTelemetryData[0][f'lastAlert{i}'] = intData
+                intData = displayNodeTelemetry(0, i)
+                if intData != -1 and localTelemetryData[0][f'lastAlert{i}'] != intData:
+                    logger.debug(intData)
+                    localTelemetryData[0][f'lastAlert{i}'] = intData
 
             if retry_int and int_enabled:
                 try:
@@ -2534,22 +2119,19 @@ async def dataPersistenceLoop():
         saveAllData()
 
 def exit_handler():
-    # Close the interface and save all data
-    logger.debug(f"System: Closing Autoresponder")
+    logger.debug("System: Closing Autoresponder")
     try:
-        logger.debug(f"System: Closing Interface1")
-        interface1.close()
-        if multiple_interface:
-            for i in range(2, 10):
-                if globals().get(f'interface{i}_enabled'):
-                    logger.debug(f"System: Closing Interface{i}")
-                    globals()[f'interface{i}'].close()
+        for i in range(1, 10):
+            mc = globals().get(f'interface{i}')
+            if mc:
+                logger.debug(f"System: Closing Interface{i}")
+                try:
+                    mc.close()
+                except Exception:
+                    pass
     except Exception as e:
         logger.error(f"System: closing: {e}")
 
     saveAllData()
-
-    logger.debug(f"System: Exiting")
-    asyncLoop.stop()
-    asyncLoop.close()
-    exit (0)
+    logger.debug("System: Exiting")
+    exit(0)

--- a/modules/system.py
+++ b/modules/system.py
@@ -59,9 +59,9 @@ if emergency_responder_enabled:
     
 # whoami Configuration
 if whoami_enabled:
-    trap_list_whoami = ("whoami", "📍", "whois")
+    trap_list_whoami = ("whoami", "📍", "whois", "path")
     trap_list = trap_list + trap_list_whoami
-    help_message = help_message + ", whoami"
+    help_message = help_message + ", whoami, path"
 
 # Solar Conditions Configuration
 if solar_conditions_enabled:
@@ -331,6 +331,7 @@ if ble_count > 1:
 
 # Interface globals — actual connections created in async init_interfaces()
 logger.debug("System: Declaring interface globals (MeshCore async init deferred)")
+_bot_start_time = time.time()
 interface1 = interface2 = interface3 = interface4 = interface5 = interface6 = interface7 = interface8 = interface9 = None
 retry_int1 = retry_int2 = retry_int3 = retry_int4 = retry_int5 = retry_int6 = retry_int7 = retry_int8 = retry_int9 = False
 myNodeNum1 = myNodeNum2 = myNodeNum3 = myNodeNum4 = myNodeNum5 = myNodeNum6 = myNodeNum7 = myNodeNum8 = myNodeNum9 = "000000000000"
@@ -340,11 +341,19 @@ my_node_ids = []
 # Contact cache: pubkey_prefix (12-char hex) -> {name_long, name_short, pubkey, snr, last_seen}
 _contacts = {}
 
+# Bot's own crypto identity (populated at startup from mc.commands.export_private_key)
+_bot_private_key: bytes | None = None
+_bot_public_key:  bytes | None = None
+
+def get_bot_keys():
+    """Return (private_key_bytes, public_key_bytes) or (None, None) if not yet loaded."""
+    return _bot_private_key, _bot_public_key
+
 def get_interface(nodeInt=1):
     """Return the live MeshCore interface object for the given slot."""
     return globals().get(f'interface{nodeInt}')
 
-def update_contact(pubkey_prefix, name_long="", name_short="", pubkey="", snr=0):
+def update_contact(pubkey_prefix, name_long="", name_short="", pubkey="", snr=0, lat=None, lon=None):
     """Upsert a contact in the in-memory cache."""
     existing = _contacts.get(pubkey_prefix, {})
     _contacts[pubkey_prefix] = {
@@ -353,6 +362,8 @@ def update_contact(pubkey_prefix, name_long="", name_short="", pubkey="", snr=0)
         'pubkey': pubkey or existing.get('pubkey', ''),
         'snr': snr,
         'last_seen': time.time(),
+        'lat': lat if lat is not None else existing.get('lat'),
+        'lon': lon if lon is not None else existing.get('lon'),
     }
 
 async def _connect_interface(i):
@@ -360,7 +371,10 @@ async def _connect_interface(i):
     interface_type = globals().get(f'interface{i}_type', '').lower()
     if interface_type == 'serial':
         port = globals().get(f'port{i}')
-        return await MeshCore.create_serial(port) if port else await MeshCore.create_serial()
+        if not port:
+            logger.critical(f"System: Interface{i} serial type requires a port in config.ini")
+            return None
+        return await MeshCore.create_serial(port)
     elif interface_type == 'tcp':
         host = globals().get(f'hostname{i}', '127.0.0.1')
         port = 5000
@@ -385,8 +399,39 @@ async def init_interfaces():
             continue
         try:
             mc = await _connect_interface(i)
+            if mc is None:
+                logger.critical(f"System: Interface{i} returned None — no response from radio on {globals().get(f'port{i}', '?')}. Check connection and baud rate.")
+                exit()
             globals()[f'interface{i}'] = mc
-            logger.debug(f"System: Interface{i} connected via {interface_type}")
+            logger.info(f"System: Interface{i} connected via {interface_type}")
+            await mc.start_auto_message_fetching()
+            logger.debug(f"System: Interface{i} auto message fetching started")
+            # Populate bot's own pubkey prefix from radio self_info
+            self_info = mc.self_info or {}
+            own_pubkey = self_info.get('public_key', '')
+            own_name = self_info.get('name', '')
+            if own_pubkey:
+                own_prefix = own_pubkey[:12]
+                globals()[f'myNodeNum{i}'] = own_prefix
+                logger.info(f"System: Interface{i} self: {own_name} ({own_prefix})")
+            # Export private key for DM decryption from raw packets
+            try:
+                global _bot_private_key, _bot_public_key
+                from meshcore import EventType as _ET
+                key_result = await mc.commands.export_private_key()
+                if key_result and hasattr(key_result, 'payload') and isinstance(key_result.payload, dict):
+                    pk = key_result.payload.get('private_key')
+                    if pk:
+                        _bot_private_key = pk
+                        import nacl.bindings as _nacl
+                        _bot_public_key = _nacl.crypto_scalarmult_ed25519_base_noclamp(pk[:32])
+                        logger.info(f"System: Interface{i} private key loaded, pub:{_bot_public_key.hex()[:12]}")
+                    else:
+                        logger.warning(f"System: Interface{i} private key export returned no key")
+                else:
+                    logger.warning(f"System: Interface{i} private key export not available (enable ENABLE_PRIVATE_KEY_EXPORT=1 in firmware)")
+            except Exception as e:
+                logger.warning(f"System: Interface{i} private key export failed: {e}")
             try:
                 await mc.commands.get_contacts()
             except Exception:
@@ -522,6 +567,21 @@ def get_num_from_short_name(short_name, nodeInt=1):
         if info.get('name_short', '').lower() == short_lower:
             return prefix
     return str(short_name)
+
+def find_contacts_by_name(query):
+    """Search contacts by name_long (case-insensitive substring) or pubkey prefix (hex prefix match).
+    Returns list of (prefix, name_long) tuples — 0, 1, or many."""
+    q = str(query).lower().strip()
+    if not q:
+        return []
+    is_hex = all(c in '0123456789abcdef' for c in q)
+    results = []
+    for prefix, info in _contacts.items():
+        if is_hex and prefix.startswith(q):
+            results.append((prefix, info.get('name_long', prefix)))
+        elif not is_hex and q in info.get('name_long', prefix).lower():
+            results.append((prefix, info.get('name_long', prefix)))
+    return results
     
 def get_node_list(nodeInt=1):
     """Return a formatted string of recently-heard contacts from the cache."""
@@ -536,7 +596,13 @@ def get_node_list(nodeInt=1):
     return node_list
 
 def get_node_location(nodeID, nodeInt=1, channel=0, round_digits=2):
-    """Return [lat, lon]; MeshCore contact positions not yet tracked — returns config location."""
+    """Return [lat, lon] for a contact by pubkey prefix, or bot's config location if unknown."""
+    contact = _contacts.get(str(nodeID))
+    if contact:
+        lat = contact.get('lat')
+        lon = contact.get('lon')
+        if lat is not None and lon is not None and (lat != 0.0 or lon != 0.0):
+            return [round(lat, round_digits), round(lon, round_digits)]
     if fuzz_config_location:
         return [round(latitudeValue, round_digits), round(longitudeValue, round_digits)]
     return [latitudeValue, longitudeValue]
@@ -648,6 +714,39 @@ def messageChunker(message):
     except Exception as e:
         logger.warning(f"System: Exception during message chunking: {e} (message length: {len(message)})")
         
+# --- DM send mode ---
+# "simple"  : send_msg (fire-and-forget, no ACK wait) — fast, no retry
+# "reliable": send_msg_with_retry (waits for ACK, retries via known path, falls back to flood)
+DM_SEND_MODE = "reliable"
+
+async def _send_dm(interface, dst: str, text: str) -> bool:
+    """Send a single DM chunk via the configured send mode."""
+    # Prefer full pubkey from contact cache so send_msg_with_retry can reset path
+    contact = _contacts.get(dst, {})
+    full_key = contact.get('pubkey') or dst  # 64-char hex if available, else 12-char prefix
+
+    if DM_SEND_MODE == "reliable":
+        result = await interface.commands.send_msg_with_retry(full_key, text)
+        if result is None:
+            # No ACK — likely ERR_CODE_TABLE_FULL; wait for queue to drain then try simple send
+            logger.warning(f"System: send_msg_with_retry got no ACK for {dst[:12]}, retrying after delay")
+            await asyncio.sleep(3)
+            result = await interface.commands.send_msg(full_key, text)
+            if result is None or result.is_error():
+                logger.error(f"System: Fallback send_msg also failed for {dst[:12]}")
+                return False
+            logger.debug(f"System: Fallback send_msg succeeded for {dst[:12]}")
+        elif result.is_error():
+            logger.error(f"System: send_msg_with_retry failed: {result.payload}")
+            return False
+    else:
+        result = await interface.commands.send_msg(dst, text)
+        if result is None or result.is_error():
+            logger.error(f"System: send_msg failed for {dst[:12]}")
+            return False
+    return True
+
+
 async def send_message(message, ch, nodeid=0, nodeInt=1, bypassChuncking=False, reply_id=None):
     """Send a DM or channel message via MeshCore."""
     interface = globals().get(f'interface{nodeInt}')
@@ -671,12 +770,14 @@ async def send_message(message, ch, nodeid=0, nodeInt=1, bypassChuncking=False, 
             chunkOf = f"{idx+1}/{num_chunks}"
             if nodeid == 0 or nodeid == "0":
                 logger.info(f"Device:{nodeInt} Channel:{ch} " + CustomFormatter.red + f"Chunker{chunkOf} SendingChannel: " + CustomFormatter.white + m.replace('\n', ' '))
-                await interface.commands.send_chan_msg(ch, m)
+                result = await interface.commands.send_chan_msg(ch, m)
+                if result.is_error():
+                    logger.error(f"System: send_chan_msg failed: {result.payload}")
             else:
                 dst = str(nodeid)
                 logger.info(f"Device:{nodeInt} " + CustomFormatter.red + f"Chunker{chunkOf} Sending DM: " + CustomFormatter.white + m.replace('\n', ' ') + CustomFormatter.purple +
-                            " To: " + CustomFormatter.white + f"{get_name_from_number(dst, 'long', nodeInt)}")
-                await interface.commands.send_msg(dst, m)
+                            " To: " + CustomFormatter.white + f"{get_name_from_number(dst, 'long', nodeInt)} [{DM_SEND_MODE}]")
+                await _send_dm(interface, dst, m)
             await asyncio.sleep(splitDelay)
         return True
     except Exception as e:
@@ -1171,6 +1272,19 @@ def initializeMeshLeaderboard():
 
 initializeMeshLeaderboard()
 
+def update_leaderboard_from_rx(nodeID: str, rssi: float = 0):
+    """Update signal strength and message count leaderboard from a received DM."""
+    global meshLeaderboard
+    if rssi != 0:
+        if rssi > meshLeaderboard['highestDBm']['value']:
+            meshLeaderboard['highestDBm'] = {'nodeID': nodeID, 'value': rssi, 'timestamp': time.time()}
+        if rssi < meshLeaderboard['weakestDBm']['value']:
+            meshLeaderboard['weakestDBm'] = {'nodeID': nodeID, 'value': rssi, 'timestamp': time.time()}
+    counts = meshLeaderboard.setdefault('nodeMessageCounts', {})
+    counts[nodeID] = counts.get(nodeID, 0) + 1
+    if counts[nodeID] > meshLeaderboard['mostMessages']['value']:
+        meshLeaderboard['mostMessages'] = {'nodeID': nodeID, 'value': counts[nodeID], 'timestamp': time.time()}
+
 # Known Meshtastic firmware PKI routing errors and practical operator guidance.
 PKI_ROUTING_ERROR_HINTS = {
     'PKI_SEND_FAIL_PUBLIC_KEY': 'bot does not have destination public key. or key is missing from the device. Add the destination nodeID to the favorite nodes list, then retry.',
@@ -1602,7 +1716,7 @@ def noisyTelemetryCheck():
     top_three = list(sorted_positionMetadata.items())[:3]
     for nodeID, data in top_three:
         if data.get('packetCount', 0) > noisyTelemetryLimit:
-            logger.warning(f"System: Noisy Telemetry Detected from NodeID:{nodeID} ShortName:{get_name_from_number(nodeID, 'short', 1)} Packets:{data.get('packetCount', 0)}")
+            logger.warning(f"System: Noisy Telemetry Detected from NodeID:{nodeID} ShortName:{get_name_from_number(nodeID, 'long', 1)} Packets:{data.get('packetCount', 0)}")
             # reset the packet count for the node
             positionMetadata[nodeID]['packetCount'] = 0
 
@@ -1649,13 +1763,13 @@ def get_mesh_leaderboard(msg, fromID, deviceID):
     if meshLeaderboard['lowestBattery']['nodeID']:
         nodeID = meshLeaderboard['lowestBattery']['nodeID']
         value = round(meshLeaderboard['lowestBattery']['value'], 1)
-        result += f"🪫 Low Battery: {value}% {get_name_from_number(nodeID, 'short', 1)}\n"
+        result += f"🪫 Low Battery: {value}% {get_name_from_number(nodeID, 'long', 1)}\n"
     
     # Longest uptime
     if meshLeaderboard['longestUptime']['nodeID']:
         nodeID = meshLeaderboard['longestUptime']['nodeID']
         value = meshLeaderboard['longestUptime']['value']
-        result += f"🕰️ Uptime: {getPrettyTime(value)} {get_name_from_number(nodeID, 'short', 1)}\n"
+        result += f"🕰️ Uptime: {getPrettyTime(value)} {get_name_from_number(nodeID, 'long', 1)}\n"
     
     # Fastest speed
     if meshLeaderboard['fastestSpeed']['nodeID']:
@@ -1663,9 +1777,9 @@ def get_mesh_leaderboard(msg, fromID, deviceID):
         value_kmh = round(meshLeaderboard['fastestSpeed']['value'], 1)
         value_mph = round(value_kmh / 1.60934, 1)
         if use_metric:
-            result += f"🚓 Speed: {value_kmh} km/h {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"🚓 Speed: {value_kmh} km/h {get_name_from_number(nodeID, 'long', 1)}\n"
         else:
-            result += f"🚓 Speed: {value_mph} mph {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"🚓 Speed: {value_mph} mph {get_name_from_number(nodeID, 'long', 1)}\n"
 
     # Tallest node
     if meshLeaderboard['tallestNode']['nodeID']:
@@ -1673,9 +1787,9 @@ def get_mesh_leaderboard(msg, fromID, deviceID):
         value_m = meshLeaderboard['tallestNode']['value']
         value_ft = round(value_m * 3.28084, 0)
         if use_metric:
-            result += f"🪜 Tallest: {int(round(value_m, 0))}m {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"🪜 Tallest: {int(round(value_m, 0))}m {get_name_from_number(nodeID, 'long', 1)}\n"
         else:
-            result += f"🪜 Tallest: {int(value_ft)}ft {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"🪜 Tallest: {int(value_ft)}ft {get_name_from_number(nodeID, 'long', 1)}\n"
     
     # Highest altitude
     if meshLeaderboard['highestAltitude']['nodeID']:
@@ -1683,9 +1797,9 @@ def get_mesh_leaderboard(msg, fromID, deviceID):
         value_m = meshLeaderboard['highestAltitude']['value']
         value_ft = round(value_m * 3.28084, 0)
         if use_metric:
-            result += f"🚀 Altitude: {int(round(value_m, 0))}m {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"🚀 Altitude: {int(round(value_m, 0))}m {get_name_from_number(nodeID, 'long', 1)}\n"
         else:
-            result += f"🚀 Altitude: {int(value_ft)}ft {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"🚀 Altitude: {int(value_ft)}ft {get_name_from_number(nodeID, 'long', 1)}\n"
 
     # Fastest airspeed
     if meshLeaderboard['fastestAirSpeed']['nodeID']:
@@ -1693,9 +1807,9 @@ def get_mesh_leaderboard(msg, fromID, deviceID):
         value_kmh = round(meshLeaderboard['fastestAirSpeed']['value'], 1)
         value_mph = round(value_kmh / 1.60934, 1)
         if use_metric:
-            result += f"✈️ Airspeed: {value_kmh} km/h {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"✈️ Airspeed: {value_kmh} km/h {get_name_from_number(nodeID, 'long', 1)}\n"
         else:
-            result += f"✈️ Airspeed: {value_mph} mph {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"✈️ Airspeed: {value_mph} mph {get_name_from_number(nodeID, 'long', 1)}\n"
     
     # Coldest temperature
     if meshLeaderboard['coldestTemp']['nodeID']:
@@ -1703,9 +1817,9 @@ def get_mesh_leaderboard(msg, fromID, deviceID):
         value_c = round(meshLeaderboard['coldestTemp']['value'], 1)
         value_f = round((value_c * 9/5) + 32, 1)
         if use_metric:
-            result += f"🥶 Coldest: {value_c}°C {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"🥶 Coldest: {value_c}°C {get_name_from_number(nodeID, 'long', 1)}\n"
         else:
-            result += f"🥶 Coldest: {value_f}°F {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"🥶 Coldest: {value_f}°F {get_name_from_number(nodeID, 'long', 1)}\n"
     
     # Hottest temperature
     if meshLeaderboard['hottestTemp']['nodeID']:
@@ -1713,57 +1827,57 @@ def get_mesh_leaderboard(msg, fromID, deviceID):
         value_c = round(meshLeaderboard['hottestTemp']['value'], 1)
         value_f = round((value_c * 9/5) + 32, 1)
         if use_metric:
-            result += f"🥵 Hottest: {value_c}°C {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"🥵 Hottest: {value_c}°C {get_name_from_number(nodeID, 'long', 1)}\n"
         else:
-            result += f"🥵 Hottest: {value_f}°F {get_name_from_number(nodeID, 'short', 1)}\n"
+            result += f"🥵 Hottest: {value_f}°F {get_name_from_number(nodeID, 'long', 1)}\n"
     
     # Worst air quality
     if meshLeaderboard['worstAirQuality']['nodeID']:
         nodeID = meshLeaderboard['worstAirQuality']['nodeID']
         value = round(meshLeaderboard['worstAirQuality']['value'], 1)
-        result += f"💨 Worst IAQ: {value} {get_name_from_number(nodeID, 'short', 1)}\n"
+        result += f"💨 Worst IAQ: {value} {get_name_from_number(nodeID, 'long', 1)}\n"
 
     # Weakest RF
     if meshLeaderboard['weakestDBm']['nodeID'] is not None:
         nodeID = meshLeaderboard['weakestDBm']['nodeID']
         value = meshLeaderboard['weakestDBm']['value']
-        result += f"📶 Weakest RF: {value} dBm {get_name_from_number(nodeID, 'short', 1)}\n"
+        result += f"📶 Weakest RF: {value} dBm {get_name_from_number(nodeID, 'long', 1)}\n"
 
     # Best RF
     if meshLeaderboard['highestDBm']['nodeID'] is not None:
         nodeID = meshLeaderboard['highestDBm']['nodeID']
         value = meshLeaderboard['highestDBm']['value']
-        result += f"📶 Best RF: {value} dBm {get_name_from_number(nodeID, 'short', 1)}\n"
+        result += f"📶 Best RF: {value} dBm {get_name_from_number(nodeID, 'long', 1)}\n"
 
     # Most Telemetry Messages
     if 'nodeTMessageCounts' in meshLeaderboard and meshLeaderboard['mostTMessages']['nodeID'] is not None:
         nodeID = meshLeaderboard['mostTMessages']['nodeID']
         value = meshLeaderboard['mostTMessages']['value']
-        result += f"📊 Most Telemetry: {value} {get_name_from_number(nodeID, 'short', 1)}\n"
+        result += f"📊 Most Telemetry: {value} {get_name_from_number(nodeID, 'long', 1)}\n"
 
     # Most Emojis
     if meshLeaderboard.get('mostEmojis', {}).get('nodeID') is not None:
         nodeID = meshLeaderboard['mostEmojis']['nodeID']
         value = meshLeaderboard['mostEmojis']['value']
-        result += f"🤪 Most Emojis: {value} {get_name_from_number(nodeID, 'short', 1)}\n"
+        result += f"🤪 Most Emojis: {value} {get_name_from_number(nodeID, 'long', 1)}\n"
     
     # Most Messages
     if 'nodeMessageCounts' in meshLeaderboard and meshLeaderboard['mostMessages']['nodeID'] is not None:
         nodeID = meshLeaderboard['mostMessages']['nodeID']
         value = meshLeaderboard['mostMessages']['value']
-        result += f"💬 Most Messages: {value} {get_name_from_number(nodeID, 'short', 1)}\n"
+        result += f"💬 Most Messages: {value} {get_name_from_number(nodeID, 'long', 1)}\n"
 
     # Most WiFi devices seen
     if meshLeaderboard.get('mostPaxWiFi', {}).get('nodeID'):
         nodeID = meshLeaderboard['mostPaxWiFi']['nodeID']
         value = meshLeaderboard['mostPaxWiFi']['value']
-        result += f"📶 PAX Wifi: {value} {get_name_from_number(nodeID, 'short', 1)}\n"
+        result += f"📶 PAX Wifi: {value} {get_name_from_number(nodeID, 'long', 1)}\n"
 
     # Most BLE devices seen
     if meshLeaderboard.get('mostPaxBLE', {}).get('nodeID'):
         nodeID = meshLeaderboard['mostPaxBLE']['nodeID']
         value = meshLeaderboard['mostPaxBLE']['value']
-        result += f"📲 PAX BLE: {value} {get_name_from_number(nodeID, 'short', 1)}\n"
+        result += f"📲 PAX BLE: {value} {get_name_from_number(nodeID, 'long', 1)}\n"
     
     # Special packet detections
     if len(meshLeaderboard['adminPackets']) > 0:
@@ -1786,15 +1900,15 @@ def get_mesh_leaderboard(msg, fromID, deviceID):
     return result
 
 def get_sysinfo(nodeID=0, deviceID=1):
-    # Get the system telemetry data for return on the sysinfo command
-    sysinfo = ''
-    stats = str(displayNodeTelemetry(nodeID, deviceID, userRequested=True)) + " 🤖👀" + str(len(seenNodes))
-    if "numPacketsTx:0" in stats or stats == -1:
-        return "Gathering Telemetry try again later⏳"
-    # replace Telemetry with Int in string
-    stats = stats.replace("Telemetry", "Int")
-    sysinfo += f"📊{stats}"
-    return sysinfo
+    uptime = getPrettyTime(time.time() - _bot_start_time)
+    contacts = len(_contacts)
+    sessions = len(seenNodes)
+    own_prefix = globals().get(f'myNodeNum{deviceID}', '????????????')
+    own_name = _contacts.get(own_prefix, {}).get('name_long', own_prefix[:6].upper()) if own_prefix != '????????????' else '?'
+    mc = get_interface(deviceID)
+    if mc and mc.self_info:
+        own_name = mc.self_info.get('name', own_name)
+    return f"📊 {own_name} up:{uptime} contacts:{contacts} session:{sessions}DMs"
 
 async def handleSignalWatcher():
     from modules.radio import signalWatcher

--- a/pong_bot.py
+++ b/pong_bot.py
@@ -90,21 +90,11 @@ def handle_ping(message_from_id, deviceID,  message, hop, snr, rssi, isDM, chann
     else:
         msg = "🔊 Can you hear me now?"
 
-    # append SNR/RSSI or hop info
-    if hop.startswith("Gateway") or hop.startswith("MQTT"):
-        msg += " [GW]"
-    elif hop.startswith("Direct"):
-        msg += " [RF]"
-    else:
-        #flood
-        msg += " [F]"
-    
-    if (float(snr) != 0 or float(rssi) != 0) and "Hop" not in hop:
+    # append SNR/RSSI or hop info (MeshCore: everything is RF, show hops or signal)
+    if "Hop" in hop:
+        msg += f"\n{hop}"
+    elif float(snr) != 0 or float(rssi) != 0:
         msg += f"\nSNR:{snr} RSSI:{rssi}"
-    elif "Hop" in hop:
-        # janky, remove the words Gateway or MQTT if present
-        hop = hop.replace("Gateway", "").replace("Direct", "").replace("MQTT", "").strip()
-        msg += f"\n{hop} "
 
     if "@" in message:
         msg = msg + " @" + message.split("@")[1]
@@ -219,12 +209,13 @@ def handle_lheard(message, nodeid, deviceID, isDM):
 async def on_contact_msg(event):
     """Handle incoming DMs via MeshCore CONTACT_MSG_RECV."""
     global seenNodes
-    payload = event.payload
-    message_from_id = str(payload.pubkey_prefix)
-    message_string = getattr(payload, 'text', '') or ''
-    snr = float(getattr(payload, 'snr', 0) or 0)
-    rssi = float(getattr(payload, 'rssi', 0) or 0)
-    hop = "Direct"
+    payload = event.payload  # dict: pubkey_prefix, text, SNR (V3 only), path_len, sender_timestamp
+    message_from_id = str(payload.get('pubkey_prefix', ''))
+    message_string = payload.get('text', '') or ''
+    snr = float(payload.get('SNR', 0) or 0)
+    rssi = 0.0
+    path_len = payload.get('path_len', 255)
+    hop = "Direct" if path_len == 255 else (f"{path_len} Hop" if path_len == 1 else f"{path_len} Hops")
     pkiStatus = (True, message_from_id)
     isDM = True
     channel_number = 0
@@ -272,13 +263,14 @@ async def on_contact_msg(event):
 async def on_channel_msg(event):
     """Handle incoming channel messages via MeshCore CHANNEL_MSG_RECV."""
     global seenNodes
-    payload = event.payload
-    message_from_id = str(getattr(payload, 'pubkey_prefix', ''))
-    message_string = getattr(payload, 'text', '') or ''
-    channel_number = int(getattr(payload, 'channel_idx', 0))
-    snr = float(getattr(payload, 'snr', 0) or 0)
-    rssi = float(getattr(payload, 'rssi', 0) or 0)
-    hop = "Direct"
+    payload = event.payload  # dict: channel_idx, text, SNR/RSSI (if logged), path_len
+    message_from_id = str(payload.get('pubkey_prefix', ''))
+    message_string = payload.get('text', '') or ''
+    channel_number = int(payload.get('channel_idx', 0))
+    snr = float(payload.get('SNR', 0) or 0)
+    rssi = float(payload.get('RSSI', 0) or 0)
+    path_len = payload.get('path_len', 0)
+    hop = "Direct" if path_len == 255 else (f"{path_len} Hop" if path_len == 1 else f"{path_len} Hops")
     pkiStatus = (False, message_from_id)
     isDM = False
     rxNode = 1
@@ -325,7 +317,8 @@ async def on_channel_msg(event):
 
 
 async def start_rx():
-    """Subscribe to MeshCore events on all connected interfaces."""
+    """Subscribe to MeshCore events on all connected interfaces, then drain buffered messages."""
+    from meshcore import EventType as ET
     import modules.system as _sys
     for i in range(1, 10):
         mc = _sys.get_interface(i)
@@ -333,6 +326,19 @@ async def start_rx():
             mc.subscribe(EventType.CONTACT_MSG_RECV, on_contact_msg)
             mc.subscribe(EventType.CHANNEL_MSG_RECV, on_channel_msg)
             logger.debug(f"System: Subscribed to events on Interface{i}")
+            # Drain messages buffered on the radio while we were offline
+            drained = 0
+            while True:
+                try:
+                    result = await mc.commands.get_msg(timeout=2.0)
+                except Exception:
+                    break
+                if result.type in (ET.NO_MORE_MSGS, ET.ERROR):
+                    break
+                drained += 1
+                await asyncio.sleep(0.05)
+            if drained:
+                logger.info(f"System: Interface{i} drained {drained} buffered message(s)")
     logger.debug("System: RX Subscriber started")
     while True:
         await asyncio.sleep(0.5)

--- a/pong_bot.py
+++ b/pong_bot.py
@@ -2,16 +2,11 @@
 # Meshtastic Autoresponder PONG Bot
 # K7MHI Kelly Keeton 2024
 
-try:
-    from pubsub import pub
-except ImportError:
-    print(f"Important dependencies are not met, try install.sh\n\n Did you mean to './launch.sh pong' using a virtual environment.")
-    exit(1)
-
 import asyncio
 import time # for sleep, get some when you can :)
 from datetime import datetime
 import random
+from meshcore import EventType
 from modules.log import logger, CustomFormatter, msgLogger
 import modules.settings as my_settings
 from modules.system import *
@@ -221,298 +216,126 @@ def handle_lheard(message, nodeid, deviceID, isDM):
     # bot_response += getNodeTelemetry(deviceID)
     return bot_response
 
-def onReceive(packet, interface):
+async def on_contact_msg(event):
+    """Handle incoming DMs via MeshCore CONTACT_MSG_RECV."""
     global seenNodes
-    # Priocess the incoming packet, handles the responses to the packet with auto_response()
-    # Sends the packet to the correct handler for processing
+    payload = event.payload
+    message_from_id = str(payload.pubkey_prefix)
+    message_string = getattr(payload, 'text', '') or ''
+    snr = float(getattr(payload, 'snr', 0) or 0)
+    rssi = float(getattr(payload, 'rssi', 0) or 0)
+    hop = "Direct"
+    pkiStatus = (True, message_from_id)
+    isDM = True
+    channel_number = 0
+    rxNode = 1
 
-    # extract interface details from inbound packet
-    rxType = type(interface).__name__
-
-    # Valies assinged to the packet
-    rxNode = message_from_id = snr = rssi = hop = hop_away = channel_number = hop_start = hop_count = hop_limit = 0
-    pkiStatus = (False, 'ABC')
-    replyIDset = False
-    rxNodeHostName = None
-    emojiSeen = False
-    simulator_flag = False
-    isDM = False
-    channel_name = "unknown"
-    session_passkey = None
-    playingGame = False
-
-    if DEBUGpacket:
-        # Debug print the interface object
-        for item in interface.__dict__.items():
-            intDebug = f"{item}\n"
-        logger.debug(f"System: Packet Received on {rxType} Interface\n {intDebug} \n END of interface \n")
-        # Debug print the packet for debugging
-        logger.debug(f"Packet Received\n {packet} \n END of packet \n")
-
-    # determine the rxNode based on the interface type
-    if rxType == 'TCPInterface':
-        rxHost = interface.__dict__.get('hostname', 'unknown')
-        rxNodeHostName = interface.__dict__.get('ip', None)
-        rxNode = next(
-            (i for i in range(1, 10)
-             if multiple_interface and rxHost and
-             globals().get(f'hostname{i}', '').split(':', 1)[0] in rxHost and
-             globals().get(f'interface{i}_type', '') == 'tcp'),None)
-
-    if rxType == 'SerialInterface':
-        rxInterface = interface.__dict__.get('devPath', 'unknown')
-        rxNode = next(
-            (i for i in range(1, 10)
-             if globals().get(f'port{i}', '') in rxInterface),None)
-    
-    if rxType == 'BLEInterface':
-        rxNode = next(
-            (i for i in range(1, 10)
-             if globals().get(f'interface{i}_type', '') == 'ble'),0)
-        
-    if rxNode is None:
-        # default to interface 1 ## FIXME needs better like a default interface setting or hash lookup
-        if 'decoded' in packet and packet['decoded']['portnum'] in ['ADMIN_APP', 'SIMULATOR_APP']:
-            session_passkey = packet.get('decoded', {}).get('admin', {}).get('sessionPasskey', None)
-        rxNode = 1
-    
-    # check if the packet has a channel flag use it ## FIXME needs to be channel hash lookup
-    if packet.get('channel'):
-        channel_number = packet.get('channel')
-        channel_name = "unknown"
-        try:
-            res = resolve_channel_name(channel_number, rxNode, interface)
-            if res:
-                try:
-                    channel_name, _ = res
-                except Exception:
-                    channel_name = "unknown"
-            else:
-                # Search all interfaces for this channel
-                cache = build_channel_cache()
-                found_on_other = None
-                for device in cache:
-                    for chan_name, info in device.get("channels", {}).items():
-                        if str(info.get('number')) == str(channel_number) or str(info.get('hash')) == str(channel_number):
-                            found_on_other = device.get("interface_id")
-                            found_chan_name = chan_name
-                            break
-                    if found_on_other:
-                        break
-                if found_on_other and found_on_other != rxNode:
-                    logger.debug(
-                        f"System: Received Packet on Channel:{channel_number} ({found_chan_name}) on Interface:{rxNode}, but this channel is configured on Interface:{found_on_other}"
-                    )
-        except Exception as e:
-            logger.debug(f"System: channel resolution error: {e}")
-
-        #debug channel info
-        # if "unknown" in str(channel_name):
-        #     logger.debug(f"System: Received Packet on Channel:{channel_number} on Interface:{rxNode}")
-        # else:
-        #     logger.debug(f"System: Received Packet on Channel:{channel_number} Name:{channel_name} on Interface:{rxNode}")
-
-    # check if the packet has a simulator flag
-    simulator_flag = packet.get('decoded', {}).get('simulator', False)
-    if isinstance(simulator_flag, dict):
-        # assume Software Simulator
-        simulator_flag = True
-
-    # set the message_from_id
-    message_from_id = packet['from']
-
-    # if message_from_id is not in the seenNodes list add it
+    # Track sender
     if not any(node.get('nodeID') == message_from_id for node in seenNodes):
-        seenNodes.append({'nodeID': message_from_id, 'rxInterface': rxNode, 'channel': channel_number, 'welcome': False, 'first_seen': time.time(), 'lastSeen': time.time()})
+        seenNodes.append({'nodeID': message_from_id, 'rxInterface': rxNode, 'channel': channel_number,
+                          'welcome': False, 'first_seen': time.time(), 'lastSeen': time.time()})
     else:
-        # update lastSeen time
         for node in seenNodes:
             if node.get('nodeID') == message_from_id:
                 node['lastSeen'] = time.time()
                 break
 
-    # CHECK with ban_hammer() if the node is banned
-    if str(message_from_id) in my_settings.bbs_ban_list or str(message_from_id) in my_settings.autoBanlist:
-        logger.warning(f"System: Banned Node {message_from_id} tried to send a message. Ignored. Try adding to node firmware-blocklist")
+    update_contact(message_from_id, snr=snr)
+
+    if message_from_id in my_settings.bbs_ban_list or message_from_id in my_settings.autoBanlist:
+        logger.warning(f"System: Banned contact {message_from_id} ignored")
         return
-    
-    # handle TEXT_MESSAGE_APP
-    try:
-        if 'decoded' in packet and packet['decoded']['portnum'] == 'TEXT_MESSAGE_APP':
-            message_bytes = packet['decoded']['payload']
-            message_string = message_bytes.decode('utf-8')
-            via_mqtt = packet['decoded'].get('viaMqtt', False)
-            transport_mechanism = packet['decoded'].get('transport_mechanism', 'unknown')
 
-            # check if the packet is from us
-            if message_from_id in [myNodeNum1, myNodeNum2, myNodeNum3, myNodeNum4, myNodeNum5, myNodeNum6, myNodeNum7, myNodeNum8, myNodeNum9]:
-                logger.warning(f"System: Packet from self {message_from_id} loop or traffic replay detected")
+    if not stringSafeCheck(message_string, message_from_id):
+        logger.warning(f"System: Unsafe message from {get_name_from_number(message_from_id, 'long', rxNode)}")
+        return
 
-            # get the signal strength and snr if available
-            if packet.get('rxSnr') or packet.get('rxRssi'):
-                snr = packet.get('rxSnr', 0)
-                rssi = packet.get('rxRssi', 0)
+    if help_message in message_string or welcome_message in message_string or "CMD?:" in message_string:
+        logger.warning(f"Got Own Welcome/Help header from: {get_name_from_number(message_from_id, 'long', rxNode)}")
+        return
 
-            # check if the packet has a publicKey flag use it
-            if packet.get('publicKey'):
-                pkiStatus = packet.get('pkiEncrypted', False), packet.get('publicKey', 'ABC')
-            
-            # check if the packet has replyId flag // currently unused in the code
-            if packet.get('replyId'):
-                replyIDset = packet.get('replyId', False)
-            
-            # check if the packet has emoji flag set it // currently unused in the code
-            if packet.get('emoji'):
-                emojiSeen = packet.get('emoji', False)
+    logger.info(f"Device:{rxNode} " + CustomFormatter.green + "Received DM: " + CustomFormatter.white +
+                f"{message_string} " + CustomFormatter.purple + "From: " + CustomFormatter.white +
+                f"{get_name_from_number(message_from_id, 'long', rxNode)}")
 
-            # check if the packet has a hop count flag use it
-            if packet.get('hopsAway'):
-                hop_away = packet.get('hopsAway', 0)
+    if log_messages_to_file:
+        msgLogger.info(f"Device:{rxNode} Channel:{channel_number} | {get_name_from_number(message_from_id, 'long', rxNode)} | DM | " + message_string.replace('\n', '-nl-'))
 
-            if packet.get('hopStart'):
-                hop_start = packet.get('hopStart', 0)
+    if (messageTrap(message_string) and not llm_enabled) or (message_string.split() and messageTrap(message_string.split()[0])):
+        await send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM),
+                           channel_number, message_from_id, rxNode)
+    else:
+        logger.warning(f"Device:{rxNode} Ignoring DM: {message_string} From: {get_name_from_number(message_from_id, 'long', rxNode)}")
+        await send_message(welcome_message, channel_number, message_from_id, rxNode)
 
-            if packet.get('hopLimit'):
-                hop_limit = packet.get('hopLimit', 0)
-            
-            # calculate hop count
-            hop = ""
-            if hop_limit > 0 and hop_start >= hop_limit:
-                hop_count = hop_away + (hop_start - hop_limit)
-            elif hop_limit > 0 and hop_start < hop_limit:
-                hop_count = hop_away + (hop_limit - hop_start)
-            else:
-                hop_count = hop_away
 
-            if hop_count > 0:
-                # set hop string from calculated hop count
-                hop = f"{hop_count} Hop" if hop_count == 1 else f"{hop_count} Hops"
+async def on_channel_msg(event):
+    """Handle incoming channel messages via MeshCore CHANNEL_MSG_RECV."""
+    global seenNodes
+    payload = event.payload
+    message_from_id = str(getattr(payload, 'pubkey_prefix', ''))
+    message_string = getattr(payload, 'text', '') or ''
+    channel_number = int(getattr(payload, 'channel_idx', 0))
+    snr = float(getattr(payload, 'snr', 0) or 0)
+    rssi = float(getattr(payload, 'rssi', 0) or 0)
+    hop = "Direct"
+    pkiStatus = (False, message_from_id)
+    isDM = False
+    rxNode = 1
 
-            if hop_start == hop_limit and "lora" in str(transport_mechanism).lower() and (snr != 0 or rssi != 0) and hop_count == 0:
-                # 2.7+ firmware direct hop over LoRa
-                hop = "Direct"
+    update_contact(message_from_id, snr=snr)
 
-            if via_mqtt or "mqtt" in str(transport_mechanism).lower():
-                hop = "MQTT"
-                via_mqtt = True
-            elif "udp" in str(transport_mechanism).lower():
-                hop = "Gateway"
-            
-            if hop in ("MQTT", "Gateway") and hop_count > 0:
-                hop = f" {hop_count} Hops"
+    if message_from_id in my_settings.bbs_ban_list or message_from_id in my_settings.autoBanlist:
+        return
 
-            # Add relay node info if present
-            if packet.get('relayNode') is not None:
-                relay_val = packet['relayNode']
-                last_byte = relay_val & 0xFF
-                if last_byte == 0x00:
-                    hex_val = 'FF'
-                else:
-                    hex_val = f"{last_byte:02X}"
-                hop += f" (Relay:{hex_val})"
+    if not stringSafeCheck(message_string, message_from_id):
+        return
 
-            if my_settings.enableHopLogs:
-                logger.debug(f"System: Packet HopDebugger: hop_away:{hop_away} hop_limit:{hop_limit} hop_start:{hop_start} calculated_hop_count:{hop_count} final_hop_value:{hop} via_mqtt:{via_mqtt} transport_mechanism:{transport_mechanism} Hostname:{rxNodeHostName}")
+    if help_message in message_string or welcome_message in message_string or "CMD?:" in message_string:
+        return
 
-            # check with stringSafeChecker if the message is safe
-            if stringSafeCheck(message_string, message_from_id) is False:
-                logger.warning(f"System: Possibly Unsafe Message from {get_name_from_number(message_from_id, 'long', rxNode)}")
-
-            if help_message in message_string or welcome_message in message_string or "CMD?:" in message_string:
-                # ignore help and welcome messages
-                logger.warning(f"Got Own Welcome/Help header. From: {get_name_from_number(message_from_id, 'long', rxNode)}")
-                return
-        
-            # If the packet is a DM (Direct Message) respond to it, otherwise validate its a message for us on the channel
-            if packet['to'] in [myNodeNum1, myNodeNum2, myNodeNum3, myNodeNum4, myNodeNum5, myNodeNum6, myNodeNum7, myNodeNum8, myNodeNum9]:
-                # message is DM to us
-                isDM = True
-                # check if the message contains a trap word, DMs are always responded to
-                if (messageTrap(message_string) and not llm_enabled) or messageTrap(message_string.split()[0]):
-                    # log the message to stdout
-                    logger.info(f"Device:{rxNode} Channel: {channel_number} " + CustomFormatter.green + f"Received DM: " + CustomFormatter.white + f"{message_string} " + CustomFormatter.purple +\
-                                "From: " + CustomFormatter.white + f"{get_name_from_number(message_from_id, 'long', rxNode)}")
-                    # respond with DM
-                    send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM), channel_number, message_from_id, rxNode)
-                else:
-                    logger.warning(f"Device:{rxNode} Ignoring DM: {message_string} From: {get_name_from_number(message_from_id, 'long', rxNode)}")
-                    send_message(welcome_message, channel_number, message_from_id, rxNode)
-                    
-                    # log the message to the message log
-                    if log_messages_to_file:
-                        msgLogger.info(f"Device:{rxNode} Channel:{channel_number} | {get_name_from_number(message_from_id, 'long', rxNode)} | DM | " + message_string.replace('\n', '-nl-'))
-            else:
-                # message is on a channel
-                if messageTrap(message_string):
-                    if ignoreDefaultChannel and channel_number == publicChannel:
-                        logger.debug(f"System: ignoreDefaultChannel CMD:{message_string} From: {get_name_from_number(message_from_id, 'short', rxNode)}")
-                    else:
-                        # message is for bot to respond to
-                        logger.info(f"Device:{rxNode} Channel:{channel_number} " + CustomFormatter.green + "ReceivedChannel: " + CustomFormatter.white + f"{message_string} " + CustomFormatter.purple +\
-                                    "From: " + CustomFormatter.white + f"{get_name_from_number(message_from_id, 'long', rxNode)}")
-                        if useDMForResponse:
-                            # respond to channel message via direct message
-                            send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM), channel_number, message_from_id, rxNode)
-                        else:
-                            # or respond to channel message on the channel itself
-                            if channel_number == my_settings.publicChannel and my_settings.antiSpam:
-                                # warning user spamming default channel
-                                logger.warning(f"System: AntiSpam protection, sending DM to: {get_name_from_number(message_from_id, 'long', rxNode)}")
-                            
-                                # respond to channel message via direct message
-                                send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM), channel_number, message_from_id, rxNode)
-                            else:
-                                # respond to channel message on the channel itself
-                                send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM), channel_number, 0, rxNode)
-
-                else:
-                    # message is not for bot to respond to
-                    # ignore the message but add it to the message history list
-                    if my_settings.zuluTime:
-                        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                    else:
-                        timestamp = datetime.now().strftime("%Y-%m-%d %I:%M:%S%p")
-                    
-                    if len(msg_history) < storeFlimit:
-                        msg_history.append((get_name_from_number(message_from_id, 'long', rxNode), message_string, channel_number, timestamp, rxNode))
-                    else:
-                        msg_history.pop(0)
-                        msg_history.append((get_name_from_number(message_from_id, 'long', rxNode), message_string, channel_number, timestamp, rxNode))
-
-                    # print the message to the log and sdout
-                    logger.info(f"Device:{rxNode} Channel:{channel_number} " + CustomFormatter.green + "Ignoring Message:" + CustomFormatter.white +\
-                                f" {message_string} " + CustomFormatter.purple + "From:" + CustomFormatter.white + f" {get_name_from_number(message_from_id)}")
-                    if log_messages_to_file:
-                        msgLogger.info(f"Device:{rxNode} Channel:{channel_number} | {get_name_from_number(message_from_id, 'long', rxNode)} | " + message_string.replace('\n', '-nl-'))
-
-                     # repeat the message on the other device
-                    if my_settings.repeater_enabled and multiple_interface:
-                        # wait a responseDelay to avoid message collision from lora-ack.
-                        time.sleep(my_settings.responseDelay)
-                        rMsg = (f"{message_string} From:{get_name_from_number(message_from_id, 'short', rxNode)}")
-                        # if channel found in the repeater list repeat the message
-                        if str(channel_number) in my_settings.repeater_channels:
-                            for i in range(1, 10):
-                                if globals().get(f'interface{i}_enabled', False) and i != rxNode:
-                                    logger.debug(f"Repeating message on Device{i} Channel:{channel_number}")
-                                    send_message(rMsg, channel_number, 0, i)
-                                    time.sleep(my_settings.responseDelay)
+    if messageTrap(message_string):
+        if ignoreDefaultChannel and channel_number == publicChannel:
+            logger.debug(f"System: ignoreDefaultChannel CMD:{message_string} From: {get_name_from_number(message_from_id, 'short', rxNode)}")
         else:
-            # Evaluate non TEXT_MESSAGE_APP packets
-            consumeMetadata(packet, rxNode, channel_number)
-    except KeyError as e:
-        logger.critical(f"System: Error processing packet: {e} Device:{rxNode}")
-        logger.debug(f"System: Error Packet = {packet}")
+            logger.info(f"Device:{rxNode} Channel:{channel_number} " + CustomFormatter.green + "ReceivedChannel: " +
+                        CustomFormatter.white + f"{message_string} " + CustomFormatter.purple + "From: " +
+                        CustomFormatter.white + f"{get_name_from_number(message_from_id, 'long', rxNode)}")
+            if useDMForResponse:
+                await send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM),
+                                   channel_number, message_from_id, rxNode)
+            else:
+                await send_message(auto_response(message_string, snr, rssi, hop, pkiStatus, message_from_id, channel_number, rxNode, isDM),
+                                   channel_number, 0, rxNode)
+    else:
+        if my_settings.zuluTime:
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        else:
+            timestamp = datetime.now().strftime("%Y-%m-%d %I:%M:%S%p")
+        if len(msg_history) < storeFlimit:
+            msg_history.append((get_name_from_number(message_from_id, 'long', rxNode), message_string, channel_number, timestamp, rxNode))
+        else:
+            msg_history.pop(0)
+            msg_history.append((get_name_from_number(message_from_id, 'long', rxNode), message_string, channel_number, timestamp, rxNode))
+        logger.info(f"Device:{rxNode} Channel:{channel_number} " + CustomFormatter.green + "Ignoring Message:" +
+                    CustomFormatter.white + f" {message_string} " + CustomFormatter.purple + "From:" +
+                    CustomFormatter.white + f" {get_name_from_number(message_from_id, 'long', rxNode)}")
+        if log_messages_to_file:
+            msgLogger.info(f"Device:{rxNode} Channel:{channel_number} | {get_name_from_number(message_from_id, 'long', rxNode)} | " + message_string.replace('\n', '-nl-'))
+
 
 async def start_rx():
-    # Start the receive subscriber using pubsub via meshtastic library
-    pub.subscribe(onReceive, 'meshtastic.receive')
-    pub.subscribe(onDisconnect, 'meshtastic.connection.lost')
+    """Subscribe to MeshCore events on all connected interfaces."""
+    import modules.system as _sys
+    for i in range(1, 10):
+        mc = _sys.get_interface(i)
+        if mc:
+            mc.subscribe(EventType.CONTACT_MSG_RECV, on_contact_msg)
+            mc.subscribe(EventType.CHANNEL_MSG_RECV, on_channel_msg)
+            logger.debug(f"System: Subscribed to events on Interface{i}")
     logger.debug("System: RX Subscriber started")
-    # here we go loopty loo
     while True:
         await asyncio.sleep(0.5)
-        pass
 
 def handle_boot(mesh=True):
     try:
@@ -662,11 +485,12 @@ def handle_boot(mesh=True):
         logger.error(f"System: Error during boot: {e}")
 
 
-# Hello World 
+# Hello World
 async def main():
     tasks = []
-    
+
     try:
+        await init_interfaces()  # Connect to MeshCore radio(s) before anything else
         handle_boot(mesh=False) # pong bot
         # Create core tasks
         tasks.append(asyncio.create_task(start_rx(), name="mesh_rx"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-meshtastic
-PyPubSub
+meshcore
+pycryptodome
 ephem
 requests
 maidenhead


### PR DESCRIPTION
## Summary

Completes the MeshCore migration for `mesh_bot.py` and fixes the
bbslink BBS sync feature to work correctly in the async environment.

### MeshCore migration
- Replace Meshtastic (`pubsub`, `meshtastic` library) radio backend
  with MeshCore (`meshcore` / EventType)
- Async `on_contact_msg` and `on_channel_msg` event handlers for DM
  and channel message dispatch
- All `send_message` calls updated to use `asyncio.ensure_future`
  where called from sync contexts

### BBSLink fixes & improvements
- `bbs_sync_posts` made async; `time.sleep` replaced with
  `asyncio.sleep` — event loop no longer blocks during sync
- `bbslink_enabled` guard moved before peer check — nothing runs
  when the feature is disabled
- `bbslink_whitelist` replaced by `bbslink_peers`: a single list that
  serves as both the scheduler's target list and the inbound whitelist
  (empty = open mode, any node may sync)
- Scheduler `value = link`: sends `bbslink 0` as a DM to each
  configured peer; falls back to channel broadcast when no peers set
- Dead `bbslink`/`bbsack` sync lambdas removed from command dict;
  replaced by early async intercept in both message handlers

### Observability
- RX DM log now includes pubkey prefix alongside name:
  `from (a1b2c3d4e5f6) T3550 Pocket`

### Docs
- `modules/bbstools.md` rewritten with accurate MeshCore bbslink
  setup, protocol walkthrough, access modes, and scheduler config